### PR TITLE
Add wikipedia link to the popup

### DIFF
--- a/css/looma-map.css
+++ b/css/looma-map.css
@@ -60,7 +60,6 @@ img.info-image{
 .leaflet-popup-content{
     font-size: 20px;
     color: #555555;
-    height: 20vh !important;
     width:auto !important; }
 
  .leaflet-popup-tip-container {display:none;}

--- a/js/looma-map.js
+++ b/js/looma-map.js
@@ -182,7 +182,7 @@ window.onload = function () {
             {
                 loadLegend(data.legend);
             }
-            
+
         }, // end of data function
         'json'
     );
@@ -410,7 +410,7 @@ function loadAddOnLayers (layerData, information) {
                             console.log("error caught!");
                         }
                     }
-
+                    popText+="Wikipedia : <a href='../content/W4S/wp/1/"+imageData+".htm'>" + imageData +"</a><br>";
 
                     marker
                         .bindPopup(popText,{className:'capital-popup', keepInView:true, width:600, minWidth:600, maxWidth:600})
@@ -444,7 +444,7 @@ function loadAddOnLayers (layerData, information) {
                             map.setMaxBounds(bounds);
                         }
                     }
-                    
+
                     )*/
                     ;
                     return marker;


### PR DESCRIPTION
I have added a link to wikipedia on maps popup.
Currently the wikipedia link points to ../content/w4s/wp/1/[Place_Name]
Please change this to what it has to be,I was not sure of it.