### PR TITLE
History Timeline Editor: clearer Add-event UI, popup images, drag-to-reorder

### DIFF
--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -2,7 +2,9 @@
 LOOMA css file
 Filename: looma-edit-history.css
 Description: styles for the History Timeline Editor (looma-edit-history.php).
-             Based on looma-edit-slideshow.css, adapted for editable event cards.
+             The timeline mirrors the read-only viewer (css/looma-history.css): a horizontal
+             yellow line with events alternating above/below, Comic Sans title/date buttons,
+             on a scrollable palegoldenrod field. Adds in-place editing chrome.
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
 */
@@ -11,218 +13,288 @@ body {
     margin: 0;
     background-color: #e3e3e3;
     color: black;
-}
-#main-container {
-    padding: 1vh;
-    display: grid;
-    grid-gap: 1vh;
-    grid-template-columns: 28vw 60vw 5vw 5vw;
-    grid-template-rows: 5vh 13vh 30vh 40vh;
-    background-color: lightgray;
     font-family: "Comic Sans MS", cursive, sans-serif;
-    color: black;
 }
-#main-container > div { border-radius: 4px; color: green; }
+#main-container { padding: 1vh; }
 
+/* ---- header ---- */
 #header {
-    grid-column: 1/-1;
-    grid-row: 1;
-    vertical-align: middle;
+    height: 7vh;
     background-color: #F2C01B;
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+    padding: 0 1vw;
 }
-#header span { margin-bottom: 6px; }
-#title { float: left; padding-left: 5vw; }
+#title { font-size: 1.3em; }
+#editor-name { font-weight: bold; font-size: 1.2em; }
 
-#search-bar {
-    grid-column: 1/-1;
-    grid-row: 2;
-    position: relative;
-    background-color: white;
+/* ---- toolbar ---- */
+#toolbar-row {
+    height: 6vh;
+    display: flex;
+    align-items: center;
+    gap: 1vw;
+    padding: 0.5vh 1vw;
 }
-div#search-panel { height: 100%; }
-#search span { font-weight: bold; }
-#grade-div, #subject-div, #chapter-div { display: inline-block; }
-#search input { font: inherit; }
-
-.all-transparent { opacity: .3; }
-
-#outerResultsDiv {
-    grid-column: 1;
-    grid-row: 3;
-    overflow: hidden;
-    background-color: white;
-}
-#previewpanel {
-    grid-column: 2/-1;
-    grid-row: 3;
-    background-color: white;
-    overflow: hidden;
-}
-#timeline    { grid-column: 1/-3; grid-row: 4; }
-#timelineLeft  { grid-column: -3 / -2; grid-row: 4; }
-#timelineRight { grid-column: -2 / -1; grid-row: 4; }
-
-button {
-    display: inline;
-    border-radius: 0.313em;
-    height: 5vh;
-    white-space: nowrap;
-    font-size: 1.5em;
-    margin-top: 3px;
-}
-button#add-event {
-    position: absolute;
-    right: 1vw;
-    top: 1vh;
+#add-event {
     background-color: #2E3192;
     color: white;
     border: none;
-    padding: 0 1vw;
-}
-
-p.hint  { padding: 2px 0 0 0; color: #aaa; font-size: 1.2em; }
-span.hint { float: left; margin: 5vh 0 0 6vh; color: #aaa; font-size: 2em; z-index: -1; }
-
-/* FILECOMMANDS */
-#filecommands { position: absolute; width: 15vw; right: 5vw; top: 0.5vh; }
-.btn-group, #cmd-btn {
-    font-family: "Comic Sans MS", cursive, sans-serif;
-    padding: 0; margin-bottom: 1vh; width: 100%;
-}
-.dropdown-menu { padding: 10px; background-color: white; z-index: 1; }
-.dropdown-item {
-    font-size: 1.2em; margin-top: 2px; font: inherit;
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#e5e5e5));
-}
-.dropdown-item:hover {
-    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#87cefa));
-    color: white;
-}
-#dismiss {
-    color: white; background-color: red; border-color: red;
-    height: 5vh; width: 4vw;
-    background-image: url("../images/back-arrow.png");
-    background-size: 90% 90%; background-repeat: no-repeat;
-    position: absolute; bottom: 1vh; right: 3vw; z-index: 2;
-}
-
-/*************** Search Results pane ***********************/
-#innerResultsMenu { height: 10%; z-index: 1; display: block; padding: 5px; }
-#innerResultsDiv  { overflow-y: auto; height: 90%; }
-.result_ID { font-size: 0.7em; font-style: normal; }
-.resultitem { padding: 3px; border-bottom: 1px solid #000; overflow: auto; }
-.resultitem .remove { display: none; }
-.textdiv p { margin: 0 auto; }
-.resultsimg {
-    float: left; width: 6vw; min-height: 8vh; max-height: 8vh;
-    box-shadow: 0px 0px 10px #888888; cursor: pointer;
-}
-.buttondiv button { float: right; font-size: 1em; height: 4vh; }
-.activityDiv { overflow: auto; }
-.thumbnaildiv, .textdiv { padding: 0.4vw; display: inline-block; float: left; }
-.textdiv { max-width: 12vw; }
-
-/************* Preview panel ***************/
-#preview { position: relative; height: 100%; text-align: center; }
-#displayImage { position: relative; max-height: 100%; display: block; margin: 0 auto; }
-#previewpanel p { margin: 10px; }
-
-/************* Timeline of event cards ***************/
-#timeline {
-    background: #fff;
-    height: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    box-shadow: 0px 0px 25px #C4C4C4;
-}
-.timelineCenter {
-    min-width: 100%;
-    height: 100%;
-    display: flex;
-    flex-wrap: nowrap;
-    align-items: stretch;
-}
-#timelineLeft {
-    background-image: url("../images/carrot-back.png");
-    background-repeat: no-repeat; background-size: 100% 100%; background-color: white;
-}
-#timelineRight {
-    background-image: url("../images/carrot-fwd.png");
-    background-repeat: no-repeat; background-size: 100% 100%; background-color: white;
-}
-.timelineScroll { height: 90%; }
-
-/* individual event card */
-.eventCard {
-    flex: 0 0 22vw;
-    margin: 0.6vh 0.5vw;
-    padding: 0.4vw;
-    background-color: #fbf7e3;
-    border: 2px solid #d8cf9a;
-    border-radius: 6px;
-    display: flex;
-    flex-direction: column;
-    box-shadow: 0px 0px 8px #bbb;
-}
-.eventCard.activeCard {
-    border-color: #2E3192;
-    box-shadow: 0px 0px 10px #2E3192;
-}
-.ev-head {
-    display: flex;
-    align-items: center;
-    background-color: #dadaff;
-    border-radius: 4px;
-    padding: 2px;
-    margin-bottom: 3px;
-    cursor: move;               /* drag handle to reorder */
-}
-.ev-head .ev-date {
-    flex: 1;
-    font-weight: bold;
-    font-size: 1.1em;
-    border: none;
-    background: transparent;
-}
-.ev-remove {
-    height: 3vh; width: 3vh;
-    font-size: 1.2em; line-height: 1;
-    color: white; background-color: #c33; border: none; border-radius: 3px;
-    margin: 0; padding: 0;
+    border-radius: 5px;
+    font: inherit;
+    font-size: 1.2em;
+    padding: 0.6vh 1.2vw;
     cursor: pointer;
 }
-.eventCard input,
-.eventCard textarea {
-    font: inherit;
-    font-size: 0.95em;
-    margin: 2px 0;
-    padding: 2px 4px;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-    width: 100%;
-    box-sizing: border-box;
+#add-event:hover { background-color: #3d40c0; }
+.timelineScroll {
+    font-size: 1.4em;
+    width: 3vw;
+    height: 5vh;
+    border: 1px solid #aaa;
+    border-radius: 5px;
+    background: white;
+    cursor: pointer;
 }
-.eventCard .ev-title { font-weight: bold; }
-.eventCard .ev-ntitle, .eventCard .ev-ndate, .eventCard .ev-ndesc { color: #555; }
-.eventCard textarea { flex: 1; min-height: 4vh; resize: none; }
+.edit-hint { color: #666; font-size: 0.95em; }
 
-/* linked-activity chips */
-.ev-activities { display: flex; flex-wrap: wrap; margin-top: 2px; }
-.ev-chip {
-    display: inline-flex;
+/* ---- the timeline field (mirrors looma-history.php #playground) ---- */
+#playground {
+    position: relative;
+    background-color: palegoldenrod;
+    border: 0.1vh solid #ccc;
+    border-radius: 4px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    height: 78vh;
+    width: 100%;
+}
+#empty-hint {
+    position: absolute;
+    top: 40%;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    color: #8a7f4a;
+    font-size: 1.6em;
+    line-height: 1.6;
+    pointer-events: none;
+}
+.timeline { height: 100%; }
+.timeline ol {
+    list-style: none;
+    margin: 0;
+    padding: 0 6vw;
+    height: 100%;
+    display: flex;
     align-items: center;
-    background-color: #e6eefc;
+    position: relative;
+    min-width: min-content;
+}
+/* the horizontal yellow line */
+.timeline ol::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 50%;
+    height: 0.6vh;
+    background: #ff0;
+    transform: translateY(-50%);
+    z-index: 0;
+}
+
+/* ---- an event on the timeline ---- */
+.event {
+    position: relative;
+    flex: 0 0 27vw;
+    height: 100%;
+}
+/* the dot where the event meets the line */
+.event::after {
+    content: '';
+    position: absolute;
+    left: 3vw;
+    top: 50%;
+    width: 1.6vh;
+    height: 1.6vh;
+    background: #d9b800;
+    border: 0.3vh solid #fff;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 1;
+}
+.timeline-description {
+    position: absolute;
+    left: 1.5vw;
+    width: 24vw;
+    z-index: 5;
+    display: flex;
+    flex-direction: column;
+}
+/* odd events sit ABOVE the line, even events BELOW (matches the viewer's alternation) */
+.event:nth-child(odd)  .timeline-description { bottom: 52%; }
+.event:nth-child(even) .timeline-description { top: 52%; }
+
+/* the editable title + date buttons (styled like the viewer's .dropbtn / .dropdate) */
+.dropbtn, .dropdate {
+    font: 1.6em "Comic Sans MS", cursive, sans-serif;
+    padding: 1vh;
+    min-height: 4vh;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    background: #fff;
+    outline: none;
+    cursor: text;
+    white-space: normal;
+    overflow-wrap: anywhere;
+}
+.dropbtn { font-weight: bold; margin-bottom: 0.4vh; }
+.dropdate { font-size: 1.3em; background: #dadaff; margin-bottom: 0.4vh; }
+.dropbtn:focus, .dropdate:focus { border-color: #2E3192; background: #fffde7; }
+/* placeholder text for empty editable fields */
+.dropbtn:empty:before, .dropdate:empty:before {
+    content: attr(data-placeholder);
+    color: #b0a97e;
+    font-style: italic;
+}
+
+/* per-event controls (appear on hover) */
+.event-controls {
+    display: flex;
+    gap: 0.3vw;
+    margin-bottom: 0.4vh;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.event:hover .event-controls, .event.editing .event-controls { opacity: 1; }
+.event-controls button {
+    font-size: 1em;
+    line-height: 1;
+    width: 2.4vw;
+    height: 3.4vh;
+    border: 1px solid #bbb;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    padding: 0;
+}
+.event-controls .ev-remove { color: #c33; }
+.event-controls button:hover { background: #eef; }
+.event.editing .timeline-description { filter: drop-shadow(0 0 6px #2E3192); }
+
+/* small chip showing a linked activity on the event */
+.ev-links { display: flex; flex-wrap: wrap; gap: 0.3vw; margin-top: 0.3vh; }
+.ev-link-chip {
+    font-size: 0.8em;
+    background: #e6eefc;
     border: 1px solid #9bb8e8;
     border-radius: 10px;
-    padding: 1px 4px;
-    margin: 2px 3px 0 0;
-    font-size: 0.75em;
-    max-width: 100%;
+    padding: 0 0.5vw;
+    max-width: 22vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
-.ev-chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 8vw; }
-.ev-chip-remove {
-    height: auto; width: auto;
-    font-size: 1em; line-height: 1;
-    margin: 0 0 0 3px; padding: 0 3px;
-    border: none; background: transparent; color: #c33; cursor: pointer;
+
+/* ---- details overlay ---- */
+.overlay {
+    position: fixed;
+    top: 0; left: 0;
+    width: 100%; height: 100%;
+    background: rgba(0,0,0,0.45);
+    z-index: 100;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
 }
+.details-card {
+    background: #fff;
+    margin-top: 4vh;
+    padding: 2vh 2vw;
+    border-radius: 8px;
+    width: 60vw;
+    max-height: 90vh;
+    overflow-y: auto;
+    position: relative;
+    box-shadow: 0 0 30px rgba(0,0,0,0.4);
+}
+.details-card h2 { margin-top: 0; }
+.details-card label {
+    display: block;
+    margin-top: 1.2vh;
+    font-weight: bold;
+    font-size: 0.95em;
+}
+.details-card input,
+.details-card textarea {
+    width: 100%;
+    box-sizing: border-box;
+    font: inherit;
+    font-size: 1em;
+    padding: 0.6vh 0.5vw;
+    margin-top: 0.3vh;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+}
+.details-card textarea { min-height: 8vh; resize: vertical; }
+#details-close {
+    position: absolute;
+    top: 1vh; right: 1vw;
+    width: 3vh; height: 3vh;
+    border: none; border-radius: 4px;
+    background: #c33; color: #fff;
+    font-size: 1.2em; line-height: 1; cursor: pointer;
+}
+.details-actions { margin-top: 2vh; text-align: right; }
+#details-done, #d-link-activity {
+    font: inherit; font-size: 1.05em;
+    padding: 0.7vh 1.4vw;
+    border: none; border-radius: 5px;
+    background: #2E3192; color: #fff; cursor: pointer;
+}
+#d-link-activity { background: #2e7d32; margin-top: 0.6vh; }
+
+/* linked-activity chips inside the details card */
+#d-activities { display: flex; flex-wrap: wrap; gap: 0.5vw; margin-top: 0.4vh; }
+.d-chip {
+    display: inline-flex; align-items: center;
+    background: #e6eefc; border: 1px solid #9bb8e8;
+    border-radius: 12px; padding: 0.3vh 0.6vw; font-size: 0.9em;
+}
+.d-chip button {
+    margin-left: 0.4vw; border: none; background: transparent;
+    color: #c33; cursor: pointer; font-size: 1em; line-height: 1;
+}
+
+/* activity search results inside the details card */
+#activity-search { margin-top: 1vh; border-top: 1px solid #ddd; padding-top: 1vh; }
+#activity-results { max-height: 30vh; overflow-y: auto; margin-top: 1vh; }
+.resultitem {
+    display: flex; align-items: center; gap: 0.6vw;
+    padding: 0.5vh; border-bottom: 1px solid #eee;
+}
+.resultitem img { width: 5vw; max-height: 7vh; box-shadow: 0 0 6px #aaa; }
+.resultitem .result_dn { flex: 1; margin: 0; }
+.resultitem button {
+    font: inherit; border: 1px solid #2e7d32; color: #2e7d32;
+    background: #fff; border-radius: 4px; cursor: pointer; padding: 0.3vh 0.6vw;
+}
+
+/* dismiss / back button */
+#dismiss {
+    color: white; background-color: red; border: none;
+    height: 6vh; width: 4vw;
+    background-image: url("../images/back-arrow.png");
+    background-size: 80% 80%; background-repeat: no-repeat; background-position: center;
+    position: fixed; bottom: 1vh; right: 2vw; z-index: 50; cursor: pointer;
+}
+
+/* File Commands dropdown (positioned like the other editors) */
+#filecommands { position: absolute; width: 15vw; right: 6vw; top: 1vh; z-index: 60; }
+.btn-group, #cmd-btn { font-family: "Comic Sans MS", cursive, sans-serif; padding: 0; width: 100%; }
+.dropdown-menu { padding: 10px; background-color: white; z-index: 61; }
+.dropdown-item { font-size: 1.1em; margin-top: 2px; font: inherit; }
+.dropdown-item:hover { background: #87cefa; color: white; }

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -39,7 +39,9 @@ body {
     padding: 0.5vh 1vw;
 }
 #timeline-details-btn {
-    background-color: #2E3192;
+    /* use the 'background' shorthand (not background-color) so it overrides the theme's
+       button { background: <white gradient> } rule, which otherwise paints white on top. */
+    background: #2E3192;
     color: white;
     border: none;
     border-radius: 5px;
@@ -47,8 +49,9 @@ body {
     font-size: 1.1em;
     padding: 0.6vh 1.2vw;
     cursor: pointer;
+    box-shadow: none;
 }
-#timeline-details-btn:hover { background-color: #3d40c0; }
+#timeline-details-btn:hover { background: #3d40c0; }
 .timelineScroll {
     font-size: 1.4em;
     width: 3vw;

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -38,7 +38,8 @@ body {
     gap: 1vw;
     padding: 0.5vh 1vw;
 }
-#timeline-details-btn {
+#timeline-details-btn,
+#timeline-save-btn {
     /* use the 'background' shorthand (not background-color) so it overrides the theme's
        button { background: <white gradient> } rule, which otherwise paints white on top. */
     background: #2E3192;
@@ -51,7 +52,8 @@ body {
     cursor: pointer;
     box-shadow: none;
 }
-#timeline-details-btn:hover { background: #3d40c0; }
+#timeline-details-btn:hover,
+#timeline-save-btn:hover { background: #3d40c0; }
 .timelineScroll {
     font-size: 1.4em;
     width: 3vw;

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -1,0 +1,228 @@
+/*
+LOOMA css file
+Filename: looma-edit-history.css
+Description: styles for the History Timeline Editor (looma-edit-history.php).
+             Based on looma-edit-slideshow.css, adapted for editable event cards.
+Owner: VillageTech Solutions (villagetechsolutions.org)
+Revision: Looma 7.x
+*/
+body {
+    box-sizing: border-box;
+    margin: 0;
+    background-color: #e3e3e3;
+    color: black;
+}
+#main-container {
+    padding: 1vh;
+    display: grid;
+    grid-gap: 1vh;
+    grid-template-columns: 28vw 60vw 5vw 5vw;
+    grid-template-rows: 5vh 13vh 30vh 40vh;
+    background-color: lightgray;
+    font-family: "Comic Sans MS", cursive, sans-serif;
+    color: black;
+}
+#main-container > div { border-radius: 4px; color: green; }
+
+#header {
+    grid-column: 1/-1;
+    grid-row: 1;
+    vertical-align: middle;
+    background-color: #F2C01B;
+}
+#header span { margin-bottom: 6px; }
+#title { float: left; padding-left: 5vw; }
+
+#search-bar {
+    grid-column: 1/-1;
+    grid-row: 2;
+    position: relative;
+    background-color: white;
+}
+div#search-panel { height: 100%; }
+#search span { font-weight: bold; }
+#grade-div, #subject-div, #chapter-div { display: inline-block; }
+#search input { font: inherit; }
+
+.all-transparent { opacity: .3; }
+
+#outerResultsDiv {
+    grid-column: 1;
+    grid-row: 3;
+    overflow: hidden;
+    background-color: white;
+}
+#previewpanel {
+    grid-column: 2/-1;
+    grid-row: 3;
+    background-color: white;
+    overflow: hidden;
+}
+#timeline    { grid-column: 1/-3; grid-row: 4; }
+#timelineLeft  { grid-column: -3 / -2; grid-row: 4; }
+#timelineRight { grid-column: -2 / -1; grid-row: 4; }
+
+button {
+    display: inline;
+    border-radius: 0.313em;
+    height: 5vh;
+    white-space: nowrap;
+    font-size: 1.5em;
+    margin-top: 3px;
+}
+button#add-event {
+    position: absolute;
+    right: 1vw;
+    top: 1vh;
+    background-color: #2E3192;
+    color: white;
+    border: none;
+    padding: 0 1vw;
+}
+
+p.hint  { padding: 2px 0 0 0; color: #aaa; font-size: 1.2em; }
+span.hint { float: left; margin: 5vh 0 0 6vh; color: #aaa; font-size: 2em; z-index: -1; }
+
+/* FILECOMMANDS */
+#filecommands { position: absolute; width: 15vw; right: 5vw; top: 0.5vh; }
+.btn-group, #cmd-btn {
+    font-family: "Comic Sans MS", cursive, sans-serif;
+    padding: 0; margin-bottom: 1vh; width: 100%;
+}
+.dropdown-menu { padding: 10px; background-color: white; z-index: 1; }
+.dropdown-item {
+    font-size: 1.2em; margin-top: 2px; font: inherit;
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#e5e5e5));
+}
+.dropdown-item:hover {
+    background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#87cefa));
+    color: white;
+}
+#dismiss {
+    color: white; background-color: red; border-color: red;
+    height: 5vh; width: 4vw;
+    background-image: url("../images/back-arrow.png");
+    background-size: 90% 90%; background-repeat: no-repeat;
+    position: absolute; bottom: 1vh; right: 3vw; z-index: 2;
+}
+
+/*************** Search Results pane ***********************/
+#innerResultsMenu { height: 10%; z-index: 1; display: block; padding: 5px; }
+#innerResultsDiv  { overflow-y: auto; height: 90%; }
+.result_ID { font-size: 0.7em; font-style: normal; }
+.resultitem { padding: 3px; border-bottom: 1px solid #000; overflow: auto; }
+.resultitem .remove { display: none; }
+.textdiv p { margin: 0 auto; }
+.resultsimg {
+    float: left; width: 6vw; min-height: 8vh; max-height: 8vh;
+    box-shadow: 0px 0px 10px #888888; cursor: pointer;
+}
+.buttondiv button { float: right; font-size: 1em; height: 4vh; }
+.activityDiv { overflow: auto; }
+.thumbnaildiv, .textdiv { padding: 0.4vw; display: inline-block; float: left; }
+.textdiv { max-width: 12vw; }
+
+/************* Preview panel ***************/
+#preview { position: relative; height: 100%; text-align: center; }
+#displayImage { position: relative; max-height: 100%; display: block; margin: 0 auto; }
+#previewpanel p { margin: 10px; }
+
+/************* Timeline of event cards ***************/
+#timeline {
+    background: #fff;
+    height: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    box-shadow: 0px 0px 25px #C4C4C4;
+}
+.timelineCenter {
+    min-width: 100%;
+    height: 100%;
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: stretch;
+}
+#timelineLeft {
+    background-image: url("../images/carrot-back.png");
+    background-repeat: no-repeat; background-size: 100% 100%; background-color: white;
+}
+#timelineRight {
+    background-image: url("../images/carrot-fwd.png");
+    background-repeat: no-repeat; background-size: 100% 100%; background-color: white;
+}
+.timelineScroll { height: 90%; }
+
+/* individual event card */
+.eventCard {
+    flex: 0 0 22vw;
+    margin: 0.6vh 0.5vw;
+    padding: 0.4vw;
+    background-color: #fbf7e3;
+    border: 2px solid #d8cf9a;
+    border-radius: 6px;
+    display: flex;
+    flex-direction: column;
+    box-shadow: 0px 0px 8px #bbb;
+}
+.eventCard.activeCard {
+    border-color: #2E3192;
+    box-shadow: 0px 0px 10px #2E3192;
+}
+.ev-head {
+    display: flex;
+    align-items: center;
+    background-color: #dadaff;
+    border-radius: 4px;
+    padding: 2px;
+    margin-bottom: 3px;
+    cursor: move;               /* drag handle to reorder */
+}
+.ev-head .ev-date {
+    flex: 1;
+    font-weight: bold;
+    font-size: 1.1em;
+    border: none;
+    background: transparent;
+}
+.ev-remove {
+    height: 3vh; width: 3vh;
+    font-size: 1.2em; line-height: 1;
+    color: white; background-color: #c33; border: none; border-radius: 3px;
+    margin: 0; padding: 0;
+    cursor: pointer;
+}
+.eventCard input,
+.eventCard textarea {
+    font: inherit;
+    font-size: 0.95em;
+    margin: 2px 0;
+    padding: 2px 4px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    width: 100%;
+    box-sizing: border-box;
+}
+.eventCard .ev-title { font-weight: bold; }
+.eventCard .ev-ntitle, .eventCard .ev-ndate, .eventCard .ev-ndesc { color: #555; }
+.eventCard textarea { flex: 1; min-height: 4vh; resize: none; }
+
+/* linked-activity chips */
+.ev-activities { display: flex; flex-wrap: wrap; margin-top: 2px; }
+.ev-chip {
+    display: inline-flex;
+    align-items: center;
+    background-color: #e6eefc;
+    border: 1px solid #9bb8e8;
+    border-radius: 10px;
+    padding: 1px 4px;
+    margin: 2px 3px 0 0;
+    font-size: 0.75em;
+    max-width: 100%;
+}
+.ev-chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 8vw; }
+.ev-chip-remove {
+    height: auto; width: auto;
+    font-size: 1em; line-height: 1;
+    margin: 0 0 0 3px; padding: 0 3px;
+    border: none; background: transparent; color: #c33; cursor: pointer;
+}

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -185,16 +185,34 @@ body {
 .dropbtn:empty:before { content: "(untitled)"; color: #b0a97e; font-style: italic; }
 
 /* ---- modals ---- */
+/* hidden by default; shown by adding .open (do NOT rely on the [hidden] attribute -
+   this author rule would override it). */
 .modal {
     position: fixed;
     top: 0; left: 0;
     width: 100%; height: 100%;
     background: rgba(0,0,0,0.45);
     z-index: 100;
-    display: flex;
+    display: none;
     align-items: flex-start;
     justify-content: center;
 }
+.modal.open { display: flex; }
+
+/* Nepali translation fields - collapsed until the toggle is clicked */
+.nepali-toggle {
+    margin-top: 1.6vh;
+    background: none;
+    border: none;
+    color: #2E3192;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.95em;
+    padding: 0.4vh 0;
+    text-decoration: underline;
+}
+.nepali-fields { display: none; border-left: 3px solid #dfe0f0; padding-left: 1vw; margin-top: 0.6vh; }
+.nepali-fields.show { display: block; }
 .modal-card {
     background: #fff;
     margin-top: 5vh;

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -2,9 +2,9 @@
 LOOMA css file
 Filename: looma-edit-history.css
 Description: styles for the History Timeline Editor (looma-edit-history.php).
-             The timeline mirrors the read-only viewer (css/looma-history.css): a horizontal
-             yellow line with events alternating above/below, Comic Sans title/date buttons,
-             on a scrollable palegoldenrod field. Adds in-place editing chrome.
+             Timeline mirrors the read-only viewer (css/looma-history.css): a horizontal
+             yellow line with event cards alternating above/below, on a scrollable
+             palegoldenrod field. Editing is done through two modals.
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
 */
@@ -38,17 +38,17 @@ body {
     gap: 1vw;
     padding: 0.5vh 1vw;
 }
-#add-event {
+#timeline-details-btn {
     background-color: #2E3192;
     color: white;
     border: none;
     border-radius: 5px;
     font: inherit;
-    font-size: 1.2em;
+    font-size: 1.1em;
     padding: 0.6vh 1.2vw;
     cursor: pointer;
 }
-#add-event:hover { background-color: #3d40c0; }
+#timeline-details-btn:hover { background-color: #3d40c0; }
 .timelineScroll {
     font-size: 1.4em;
     width: 3vw;
@@ -68,25 +68,14 @@ body {
     border-radius: 4px;
     overflow-x: auto;
     overflow-y: hidden;
-    height: 78vh;
+    height: 82vh;
     width: 100%;
-}
-#empty-hint {
-    position: absolute;
-    top: 40%;
-    left: 0;
-    width: 100%;
-    text-align: center;
-    color: #8a7f4a;
-    font-size: 1.6em;
-    line-height: 1.6;
-    pointer-events: none;
 }
 .timeline { height: 100%; }
 .timeline ol {
     list-style: none;
     margin: 0;
-    padding: 0 6vw;
+    padding: 0 3vw;
     height: 100%;
     display: flex;
     align-items: center;
@@ -106,17 +95,56 @@ body {
     z-index: 0;
 }
 
-/* ---- an event on the timeline ---- */
+/* ---- insert slots (the tappable "+") ---- */
+.insert-slot {
+    position: relative;
+    flex: 0 0 5vw;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.insert-btn {
+    width: 4vh;
+    height: 4vh;
+    border-radius: 50%;
+    border: 0.3vh dashed #2E3192;
+    background: #fff;
+    color: #2E3192;
+    font-size: 1.6em;
+    line-height: 1;
+    cursor: pointer;
+    z-index: 3;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+}
+.insert-btn:hover { background: #2E3192; color: #fff; }
+/* the big "insert first event" prompt on an empty timeline */
+.insert-slot.first { flex: 0 0 auto; }
+.insert-slot.first .insert-btn {
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    padding: 2vh 3vw;
+    font-size: 1.3em;
+    white-space: nowrap;
+    font-family: inherit;
+}
+
+/* ---- an event card on the timeline ---- */
 .event {
     position: relative;
-    flex: 0 0 27vw;
+    flex: 0 0 24vw;
     height: 100%;
+    cursor: pointer;
 }
 /* the dot where the event meets the line */
 .event::after {
     content: '';
     position: absolute;
-    left: 3vw;
+    left: 50%;
     top: 50%;
     width: 1.6vh;
     height: 1.6vh;
@@ -128,79 +156,36 @@ body {
 }
 .timeline-description {
     position: absolute;
-    left: 1.5vw;
-    width: 24vw;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 22vw;
     z-index: 5;
     display: flex;
     flex-direction: column;
+    align-items: stretch;
 }
-/* odd events sit ABOVE the line, even events BELOW (matches the viewer's alternation) */
-.event:nth-child(odd)  .timeline-description { bottom: 52%; }
-.event:nth-child(even) .timeline-description { top: 52%; }
+/* odd events (index 0,2,4… = "above") sit above the line; "below" sit below */
+.event.above .timeline-description { bottom: 53%; }
+.event.below .timeline-description { top: 53%; }
 
-/* the editable title + date buttons (styled like the viewer's .dropbtn / .dropdate) */
+/* title + date styled like the viewer's .dropbtn / .dropdate */
 .dropbtn, .dropdate {
-    font: 1.6em "Comic Sans MS", cursive, sans-serif;
+    font: 1.5em "Comic Sans MS", cursive, sans-serif;
     padding: 1vh;
-    min-height: 4vh;
-    border: 2px solid transparent;
-    border-radius: 4px;
+    border: 2px solid #e4dca0;
+    border-radius: 6px;
     background: #fff;
-    outline: none;
-    cursor: text;
+    text-align: center;
     white-space: normal;
     overflow-wrap: anywhere;
 }
-.dropbtn { font-weight: bold; margin-bottom: 0.4vh; }
-.dropdate { font-size: 1.3em; background: #dadaff; margin-bottom: 0.4vh; }
-.dropbtn:focus, .dropdate:focus { border-color: #2E3192; background: #fffde7; }
-/* placeholder text for empty editable fields */
-.dropbtn:empty:before, .dropdate:empty:before {
-    content: attr(data-placeholder);
-    color: #b0a97e;
-    font-style: italic;
-}
+.dropbtn { font-weight: bold; margin-bottom: 0.4vh; box-shadow: 0 0 6px #cfc68a; }
+.dropdate { font-size: 1.2em; background: #dadaff; }
+.event:hover .dropbtn { border-color: #2E3192; }
+.dropbtn:empty:before { content: "(untitled)"; color: #b0a97e; font-style: italic; }
 
-/* per-event controls (appear on hover) */
-.event-controls {
-    display: flex;
-    gap: 0.3vw;
-    margin-bottom: 0.4vh;
-    opacity: 0;
-    transition: opacity 0.15s;
-}
-.event:hover .event-controls, .event.editing .event-controls { opacity: 1; }
-.event-controls button {
-    font-size: 1em;
-    line-height: 1;
-    width: 2.4vw;
-    height: 3.4vh;
-    border: 1px solid #bbb;
-    border-radius: 4px;
-    background: #fff;
-    cursor: pointer;
-    padding: 0;
-}
-.event-controls .ev-remove { color: #c33; }
-.event-controls button:hover { background: #eef; }
-.event.editing .timeline-description { filter: drop-shadow(0 0 6px #2E3192); }
-
-/* small chip showing a linked activity on the event */
-.ev-links { display: flex; flex-wrap: wrap; gap: 0.3vw; margin-top: 0.3vh; }
-.ev-link-chip {
-    font-size: 0.8em;
-    background: #e6eefc;
-    border: 1px solid #9bb8e8;
-    border-radius: 10px;
-    padding: 0 0.5vw;
-    max-width: 22vw;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-/* ---- details overlay ---- */
-.overlay {
+/* ---- modals ---- */
+.modal {
     position: fixed;
     top: 0; left: 0;
     width: 100%; height: 100%;
@@ -210,78 +195,77 @@ body {
     align-items: flex-start;
     justify-content: center;
 }
-.details-card {
+.modal-card {
     background: #fff;
-    margin-top: 4vh;
+    margin-top: 5vh;
     padding: 2vh 2vw;
-    border-radius: 8px;
-    width: 60vw;
-    max-height: 90vh;
+    border-radius: 10px;
+    width: 46vw;
+    max-height: 88vh;
     overflow-y: auto;
     position: relative;
     box-shadow: 0 0 30px rgba(0,0,0,0.4);
 }
-.details-card h2 { margin-top: 0; }
-.details-card label {
+.modal-card h2 { margin: 0 0 1vh; }
+.modal-card label {
     display: block;
     margin-top: 1.2vh;
     font-weight: bold;
     font-size: 0.95em;
 }
-.details-card input,
-.details-card textarea {
+.modal-card input,
+.modal-card textarea {
     width: 100%;
     box-sizing: border-box;
     font: inherit;
     font-size: 1em;
-    padding: 0.6vh 0.5vw;
+    padding: 0.7vh 0.5vw;
     margin-top: 0.3vh;
     border: 1px solid #ccc;
-    border-radius: 4px;
+    border-radius: 5px;
 }
-.details-card textarea { min-height: 8vh; resize: vertical; }
-#details-close {
+.modal-card textarea { min-height: 9vh; resize: vertical; }
+.modal-close {
     position: absolute;
     top: 1vh; right: 1vw;
-    width: 3vh; height: 3vh;
-    border: none; border-radius: 4px;
-    background: #c33; color: #fff;
-    font-size: 1.2em; line-height: 1; cursor: pointer;
-}
-.details-actions { margin-top: 2vh; text-align: right; }
-#details-done, #d-link-activity {
-    font: inherit; font-size: 1.05em;
-    padding: 0.7vh 1.4vw;
+    width: 3.2vh; height: 3.2vh;
     border: none; border-radius: 5px;
-    background: #2E3192; color: #fff; cursor: pointer;
+    background: #c33; color: #fff;
+    font-size: 1.3em; line-height: 1; cursor: pointer;
 }
-#d-link-activity { background: #2e7d32; margin-top: 0.6vh; }
+.modal-actions {
+    margin-top: 2vh;
+    display: flex;
+    justify-content: flex-end;
+    gap: 1vw;
+}
+.modal-actions button {
+    font: inherit; font-size: 1.05em;
+    padding: 0.8vh 1.6vw;
+    border: none; border-radius: 6px;
+    cursor: pointer;
+}
+.modal-actions .primary { background: #2E3192; color: #fff; }
+.modal-actions .primary:hover { background: #3d40c0; }
+#ev-delete { background: #c33; color: #fff; margin-right: auto; }
 
-/* linked-activity chips inside the details card */
-#d-activities { display: flex; flex-wrap: wrap; gap: 0.5vw; margin-top: 0.4vh; }
-.d-chip {
-    display: inline-flex; align-items: center;
-    background: #e6eefc; border: 1px solid #9bb8e8;
-    border-radius: 12px; padding: 0.3vh 0.6vw; font-size: 0.9em;
+/* cover image chooser */
+#tl-cover-row { display: flex; gap: 1vw; align-items: flex-start; margin-top: 0.4vh; }
+#tl-cover-preview {
+    width: 10vw; height: 10vw;
+    object-fit: cover;
+    border: 1px solid #ccc; border-radius: 6px;
+    background: #f4f4f4;
 }
-.d-chip button {
-    margin-left: 0.4vw; border: none; background: transparent;
-    color: #c33; cursor: pointer; font-size: 1em; line-height: 1;
+#tl-cover-actions { flex: 1; display: flex; flex-direction: column; gap: 0.6vh; }
+#tl-choose-image, #tl-remove-image {
+    font: inherit; font-size: 1em;
+    padding: 0.6vh 1vw;
+    border: 1px solid #2e7d32; color: #2e7d32; background: #fff;
+    border-radius: 5px; cursor: pointer;
+    align-self: flex-start;
 }
-
-/* activity search results inside the details card */
-#activity-search { margin-top: 1vh; border-top: 1px solid #ddd; padding-top: 1vh; }
-#activity-results { max-height: 30vh; overflow-y: auto; margin-top: 1vh; }
-.resultitem {
-    display: flex; align-items: center; gap: 0.6vw;
-    padding: 0.5vh; border-bottom: 1px solid #eee;
-}
-.resultitem img { width: 5vw; max-height: 7vh; box-shadow: 0 0 6px #aaa; }
-.resultitem .result_dn { flex: 1; margin: 0; }
-.resultitem button {
-    font: inherit; border: 1px solid #2e7d32; color: #2e7d32;
-    background: #fff; border-radius: 4px; cursor: pointer; padding: 0.3vh 0.6vw;
-}
+#tl-remove-image { border-color: #c33; color: #c33; }
 
 /* dismiss / back button */
 #dismiss {

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -201,16 +201,19 @@ body {
 
 /* Nepali translation fields - collapsed until the toggle is clicked */
 .nepali-toggle {
+    display: inline-block;
     margin-top: 1.6vh;
-    background: none;
-    border: none;
+    background: #eef0fb;
+    border: 1.5px solid #2E3192;
     color: #2E3192;
     cursor: pointer;
     font: inherit;
     font-size: 0.95em;
-    padding: 0.4vh 0;
-    text-decoration: underline;
+    padding: 0.7vh 1.2vw;
+    border-radius: 6px;
+    text-decoration: none;
 }
+.nepali-toggle:hover { background: #2E3192; color: #fff; }
 .nepali-fields { display: none; border-left: 3px solid #dfe0f0; padding-left: 1vw; margin-top: 0.6vh; }
 .nepali-fields.show { display: block; }
 .modal-card {
@@ -293,6 +296,38 @@ body {
     background-size: 80% 80%; background-repeat: no-repeat; background-position: center;
     position: fixed; bottom: 1vh; right: 2vw; z-index: 50; cursor: pointer;
 }
+
+/* The global LOOMA.confirm() "Save current work…" dialog uses floated buttons of
+   differing heights. Tidy it up on this editor page: put the buttons on one line at the
+   same height, red X on the left, purple Confirm on the right. */
+.popup.confirmation {
+    font-size: 1.6em;
+    padding: 2vh 2vw;
+    text-align: right;
+    line-height: 1.4;
+}
+.popup.confirmation .popup-button {
+    float: none;
+    position: static;
+    display: inline-block;
+    vertical-align: middle;
+    width: auto;
+    min-width: 6vw;
+    height: auto;
+    margin: 1.2vh 0.4vw 0;
+    padding: 1vh 1.6vw;
+    font-size: 0.62em;
+    border: 1px solid #2E3192;
+    border-radius: 6px;
+}
+.popup.confirmation .dismiss-popup {
+    float: left;
+    min-width: 0;
+    width: auto;
+    border-color: #c33;
+}
+.popup.confirmation #confirm-popup { background: #2E3192; color: #fff; border-color: #2E3192; }
+.popup.confirmation #close-popup   { background: #fff; color: #2E3192; }
 
 /* File Commands dropdown (positioned like the other editors) */
 #filecommands { position: absolute; width: 15vw; right: 6vw; top: 1vh; z-index: 60; }

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -126,6 +126,17 @@ body {
     padding: 0;
 }
 .insert-btn:hover { background: #2E3192; color: #fff; }
+/* between-event "+" slots are secondary: de-emphasized until hovered, so the prominent
+   "Add event" (toolbar + end of timeline) is the obvious way to add an event. */
+.insert-slot:not(.first):not(.add-after) { flex: 0 0 3.5vw; }
+.insert-slot:not(.first):not(.add-after) .insert-btn {
+    width: 3vh;
+    height: 3vh;
+    font-size: 1.1em;
+    border-width: 0.2vh;
+    opacity: 0.3;
+}
+.insert-slot:not(.first):not(.add-after) .insert-btn:hover { opacity: 1; }
 /* the big "insert first event" prompt on an empty timeline */
 .insert-slot.first { flex: 0 0 auto; }
 .insert-slot.first .insert-btn {
@@ -137,6 +148,29 @@ body {
     white-space: nowrap;
     font-family: inherit;
 }
+/* prominent "Add event" slot after the last event (mirrors the toolbar button) */
+.insert-slot.add-after { flex: 0 0 auto; }
+.insert-slot.add-after .insert-btn {
+    width: auto;
+    height: auto;
+    border-radius: 8px;
+    padding: 1.4vh 2vw;
+    font-size: 1.15em;
+    white-space: nowrap;
+    font-family: inherit;
+    font-weight: bold;
+    border-style: solid;
+    background: #1b8f3a;
+    border-color: #1b8f3a;
+    color: #fff;
+    opacity: 1;
+}
+.insert-slot.add-after .insert-btn:hover { background: #23a847; color: #fff; }
+
+/* drag-to-reorder cues */
+.event { touch-action: none; }
+#timeline-ol .ui-sortable-helper .timeline-description { opacity: 0.95; }
+.event.ui-sortable-helper { z-index: 20; }
 
 /* ---- an event card on the timeline ---- */
 .event {
@@ -333,6 +367,65 @@ body {
 }
 .popup.confirmation #confirm-popup { background: #2E3192; color: #fff; border-color: #2E3192; }
 .popup.confirmation #close-popup   { background: #fff; color: #2E3192; }
+
+/* ---- event images (up to 2 per event) ---- */
+#ev-images { margin-top: 0.4vh; }
+#ev-images-list { display: flex; gap: 1vw; flex-wrap: wrap; }
+.ev-img-slot { position: relative; width: 8vw; height: 8vw; }
+.ev-img-slot img {
+    width: 100%; height: 100%;
+    object-fit: cover;
+    border: 1px solid #ccc; border-radius: 6px;
+    background: #f4f4f4;
+}
+.ev-img-remove {
+    position: absolute; top: -0.7vh; right: -0.4vw;
+    width: 2.6vh; height: 2.6vh;
+    border: none; border-radius: 50%;
+    background: #c33; color: #fff;
+    font-size: 1em; line-height: 1; cursor: pointer;
+    padding: 0;
+}
+#ev-add-image {
+    margin-top: 0.9vh;
+    font: inherit; font-size: 1em;
+    padding: 0.6vh 1vw;
+    border: 1px solid #2e7d32; color: #2e7d32; background: #fff;
+    border-radius: 5px; cursor: pointer;
+}
+#ev-add-image:hover { background: #2e7d32; color: #fff; }
+
+/* ---- image search overlay (embeds the shared Looma search panel) ---- */
+.imgsearch-card { width: 72vw; }
+/* keep the embedded search focused on pictures: hide the media/chapter switch,
+   chapter search, and the text-file type checkbox */
+#imgsearch-modal #search-kind,
+#imgsearch-modal #chapter-search,
+#imgsearch-modal #source-div,
+#imgsearch-modal #search span.typ-chk[data-id="text-chk"] { display: none; }
+#imgsearch-modal #search-panel { position: static; width: auto; }
+#results-div {
+    display: flex; flex-wrap: wrap; gap: 1vw;
+    margin-top: 1.5vh;
+    max-height: 56vh; overflow-y: auto;
+    align-content: flex-start;
+}
+.imgresult {
+    width: 12vw;
+    border: 1px solid #ccc; border-radius: 6px;
+    background: #fff; cursor: pointer;
+    padding: 0.5vh;
+    display: flex; flex-direction: column; align-items: center;
+    font: inherit;
+}
+.imgresult:hover { border-color: #2E3192; box-shadow: 0 0 8px #b9bbe6; }
+.imgresult img { width: 100%; height: 9vw; object-fit: contain; }
+.imgresult-dn {
+    font-size: 0.8em; margin-top: 0.4vh;
+    max-width: 100%;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.imgsearch-empty { color: #666; margin-top: 1.5vh; }
 
 /* File Commands dropdown (positioned like the other editors) */
 #filecommands { position: absolute; width: 15vw; right: 6vw; top: 1vh; z-index: 60; }

--- a/css/looma-edit-history.css
+++ b/css/looma-edit-history.css
@@ -38,8 +38,7 @@ body {
     gap: 1vw;
     padding: 0.5vh 1vw;
 }
-#timeline-details-btn,
-#timeline-save-btn {
+#timeline-details-btn {
     /* use the 'background' shorthand (not background-color) so it overrides the theme's
        button { background: <white gradient> } rule, which otherwise paints white on top. */
     background: #2E3192;
@@ -52,8 +51,7 @@ body {
     cursor: pointer;
     box-shadow: none;
 }
-#timeline-details-btn:hover,
-#timeline-save-btn:hover { background: #3d40c0; }
+#timeline-details-btn:hover { background: #3d40c0; }
 .timelineScroll {
     font-size: 1.4em;
     width: 3vw;

--- a/css/looma-history.css
+++ b/css/looma-history.css
@@ -372,6 +372,22 @@ button.img:hover {
     width: 3vw;
 }
 
+/* inline images added in the History editor (up to 2 per event) */
+.popup-images {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2vh;
+    margin-top: 2vh;
+    justify-content: flex-start;
+}
+.popup-image {
+    max-width: 48%;
+    max-height: 45vh;
+    object-fit: contain;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+}
+
 span.english-keyword {    word-break: break-word;
 }
 

--- a/includes/mongo-connect.php
+++ b/includes/mongo-connect.php
@@ -321,7 +321,6 @@ $TG_collection  = $loomaDB -> TG;
 $dictionary_collection = $loomaDB -> dictionary;
 $history_collection    = $loomaDB -> histories;
 $histories_collection  = $loomaDB -> histories;
-$user_histories_collection = $loomaDB -> user_histories;  // admin-created timelines (separate from the curated, read-only 'histories')
 $slideshows_collection = $loomaDB -> slideshows;
 $text_files_collection = $loomaDB -> text_files;
 $lessons_collection    = $loomaDB -> lessons;
@@ -363,7 +362,6 @@ $collections = array(
     "maps" =>          $maps_collection,
     "history" =>       $histories_collection,
     "histories" =>     $histories_collection,
-    "user_histories" => $user_histories_collection,
     "game" =>          $games_collection,
     "games" =>         $games_collection,
     "edited_videos" => $edited_videos_collection,
@@ -389,7 +387,7 @@ $local_lessons_collection     = $localdbname -> lessons;
 $local_slideshows_collection     = $localdbname -> slideshows;
 $local_textfiles_collection     = $localdbname -> text_files;
 $local_activities_collection  = $localdbname -> activities;
-$local_user_histories_collection = $localdbname -> user_histories;
+$local_histories_collection       = $localdbname -> histories;
 
 $localcollections = array(
     "lessons" =>    $local_lessons_collection,
@@ -397,7 +395,7 @@ $localcollections = array(
     "text_files" =>    $local_textfiles_collection,
     "text" =>    $local_textfiles_collection,
     "activities" => $local_activities_collection,
-    "user_histories" => $local_user_histories_collection
+    "histories" => $local_histories_collection
 );
 
 $logcollections = array(

--- a/includes/mongo-connect.php
+++ b/includes/mongo-connect.php
@@ -321,6 +321,7 @@ $TG_collection  = $loomaDB -> TG;
 $dictionary_collection = $loomaDB -> dictionary;
 $history_collection    = $loomaDB -> histories;
 $histories_collection  = $loomaDB -> histories;
+$user_histories_collection = $loomaDB -> user_histories;  // admin-created timelines (separate from the curated, read-only 'histories')
 $slideshows_collection = $loomaDB -> slideshows;
 $text_files_collection = $loomaDB -> text_files;
 $lessons_collection    = $loomaDB -> lessons;
@@ -362,6 +363,7 @@ $collections = array(
     "maps" =>          $maps_collection,
     "history" =>       $histories_collection,
     "histories" =>     $histories_collection,
+    "user_histories" => $user_histories_collection,
     "game" =>          $games_collection,
     "games" =>         $games_collection,
     "edited_videos" => $edited_videos_collection,
@@ -387,13 +389,15 @@ $local_lessons_collection     = $localdbname -> lessons;
 $local_slideshows_collection     = $localdbname -> slideshows;
 $local_textfiles_collection     = $localdbname -> text_files;
 $local_activities_collection  = $localdbname -> activities;
+$local_user_histories_collection = $localdbname -> user_histories;
 
 $localcollections = array(
     "lessons" =>    $local_lessons_collection,
     "slideshows" =>    $local_slideshows_collection,
     "text_files" =>    $local_textfiles_collection,
     "text" =>    $local_textfiles_collection,
-    "activities" => $local_activities_collection
+    "activities" => $local_activities_collection,
+    "user_histories" => $local_user_histories_collection
 );
 
 $logcollections = array(

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -3,20 +3,18 @@ LOOMA javascript file
 Filename: looma-edit-history.js
 Description: editor for user-created history timelines.
 
-    The editing surface mirrors the read-only viewer (looma-history.php): a horizontal timeline
-    with events alternating above/below a line. Each event's TITLE and DATE are edited in place
-    (tap and type). Everything else - Nepali title/date, description, and up to two linked
-    activities - is edited in a per-event details panel (the pencil button).
+    UX: a Timeline modal (title, Nepali title, cover image) opens on entry / File-New.
+    Then a blank timeline in the real viewer format (yellow line, events alternating
+    above/below). Tap a "+" insert slot to add an event, or tap an event to edit it in
+    the Event modal (title, date, description, + optional Nepali). No linked activities.
 
-    A timeline is a document in the 'user_histories' collection:
-        { dn, ft:'history', title, events: [ event, ... ] }
+    Data model (in the 'user_histories' collection):
+        { dn, ft:'history', title, ndn, thumb, events:[ event, ... ] }
     each event:
-        { title, date, popup:[description, activityId1?, activityId2?],
-          ndn?, ndate?, npopup:[nepaliDescription]? }
+        { title, date, popup:[description], ndn?, ndate?, npopup:[nepaliDescription]? }
 
-    IMPORTANT: this editor reads/writes ONLY the 'user_histories' collection. The curated,
-    read-only 'histories' collection (the 11 approved timelines) is never referenced.
-    File-menu / save-load / activity-search flow follows the Slideshow-editor patterns.
+    IMPORTANT: reads/writes ONLY the 'user_histories' collection. The curated, read-only
+    'histories' collection (the 11 approved timelines) is never referenced.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -24,171 +22,176 @@ Revision: Looma 7.x
 
 'use strict';
 
-var savedSignature = "";     //checkpoint for detecting modifications
+var DEFAULT_THUMB = 'images/logos/LoomaLogoTransparent.png';
+
 var loginname, loginlevel, loginteam;
-var $ol;                     //the #timeline-ol element
-var currentLi = null;        //the event whose details panel is open
+var savedSignature = "";
 
-var searchName = 'history-editor-search';   //used by looma-search.js
+// --- source of truth ---
+var timeline = { ndn: "", thumb: "" };   // title is kept in `currentname` (the File-menu name)
+var events = [];                          // array of {title, ndn, date, ndate, desc, ndesc}
+
+var editingIndex = null;                  // event index being edited (null => creating new)
+var insertIndex  = 0;                     // where a new event will be inserted
+var pendingThumb = "";                    // cover image chosen in the Timeline modal (data-URL or url)
+
 
 //////////////////////////////////
-///////   EVENT TIMELINE   ////////
+///////   RENDER TIMELINE  ////////
 //////////////////////////////////
 
-///////// buildEventLi  /////////  create one editable event; ev may be undefined (blank)
-function buildEventLi(ev) {
-    ev = ev || {};
-    var popup  = ev.popup  || [];
-    var npopup = ev.npopup || [];
+function renderTimeline() {
+    var $ol = $('#timeline-ol').empty();
 
+    if (events.length === 0) {
+        $ol.append(
+            '<li class="insert-slot first">' +
+            '<button class="insert-btn" data-index="0">&#43; Insert first event</button>' +
+            '</li>'
+        );
+        return;
+    }
+
+    for (var i = 0; i < events.length; i++) {
+        $ol.append(insertSlot(i));
+        $ol.append(eventCard(i));
+    }
+    $ol.append(insertSlot(events.length));
+}
+
+function insertSlot(index) {
+    return $('<li class="insert-slot"><button class="insert-btn" title="Insert event here">&#43;</button></li>')
+        .find('.insert-btn').attr('data-index', index).end();
+}
+
+function eventCard(i) {
+    var e = events[i];
     var $li = $(
         '<li class="event">' +
           '<div class="timeline-description">' +
-            '<div class="event-controls">' +
-              '<button class="ev-move-left"  title="Move earlier">&#8249;</button>' +
-              '<button class="ev-details"    title="Edit description / Nepali / activities">&#9998;</button>' +
-              '<button class="ev-remove"     title="Delete event">&times;</button>' +
-              '<button class="ev-move-right" title="Move later">&#8250;</button>' +
-            '</div>' +
-            '<div class="dropbtn"  contenteditable="true" data-placeholder="Event title"></div>' +
-            '<div class="dropdate" contenteditable="true" data-placeholder="Date"></div>' +
-            '<div class="ev-links"></div>' +
+            '<div class="dropbtn"></div>' +
+            '<div class="dropdate"></div>' +
           '</div>' +
         '</li>'
     );
-
-    $li.find('.dropbtn').text(ev.title || '');
-    $li.find('.dropdate').text(ev.date || '');
-    $li.data('ntitle', ev.ndn   || '');
-    $li.data('ndate',  ev.ndate || '');
-    $li.data('desc',   popup[0]  || '');
-    $li.data('ndesc',  npopup[0] || '');
-    if (popup[1]) $li.data('id1', popup[1]);
-    if (popup[2]) $li.data('id2', popup[2]);
-
-    renderLinks($li);
+    $li.addClass(i % 2 === 0 ? 'above' : 'below');
+    $li.attr('data-index', i);
+    $li.find('.dropbtn').text(e.title || '');
+    $li.find('.dropdate').text(e.date || '');
     return $li;
-}
-
-///////// addEvent  /////////
-function addEvent(ev) {
-    var $li = buildEventLi(ev);
-    $ol.append($li);
-    return $li;
-}
-
-///////// refreshEmptyHint  /////////
-function refreshEmptyHint() {
-    $('#empty-hint').toggle($ol.find('.event').length === 0);
-}
-
-///////// renderLinks  /////////  show a chip per linked activity on the event
-function renderLinks($li) {
-    var $links = $li.find('.ev-links').empty();
-    [['id1', 'name1'], ['id2', 'name2']].forEach(function(p) {
-        var id = $li.data(p[0]);
-        if (!id) return;
-        var $chip = $('<span class="ev-link-chip">activity&hellip;</span>');
-        $links.append($chip);
-        var nm = $li.data(p[1]);
-        if (nm) { $chip.text('▶ ' + nm); return; }
-        lookupActivityName(id, function(name) { $li.data(p[1], name); $chip.text('▶ ' + name); });
-    });
-}
-
-///////// lookupActivityName  /////////
-function lookupActivityName(id, cb) {
-    $.post('looma-database-utilities.php',
-        { cmd: 'openByID', collection: 'activities', id: id },
-        function(r) { cb((r && r.dn) ? r.dn : ('[' + id + ']')); }, 'json');
 }
 
 
 //////////////////////////////////
-///////   DETAILS PANEL    ////////
+///////   TIMELINE MODAL   ////////
 //////////////////////////////////
 
-function openDetails($li) {
-    currentLi = $li;
-    $('.event').removeClass('editing');
-    $li.addClass('editing');
-
-    $('#d-title').val($li.find('.dropbtn').text());
-    $('#d-ntitle').val($li.data('ntitle') || '');
-    $('#d-date').val($li.find('.dropdate').text());
-    $('#d-ndate').val($li.data('ndate') || '');
-    $('#d-desc').val($li.data('desc') || '');
-    $('#d-ndesc').val($li.data('ndesc') || '');
-
-    renderDetailChips();
-    $('#activity-search').attr('hidden', true);
-    $('#event-details').removeAttr('hidden');
-    $('#d-title').focus();
+function openTimelineModal() {
+    $('#tl-title').val(currentname || '');
+    $('#tl-ntitle').val(timeline.ndn || '');
+    $('#tl-cover-url').val('');
+    pendingThumb = timeline.thumb || '';
+    showCoverPreview(pendingThumb);
+    $('#timeline-modal').removeAttr('hidden');
+    $('#tl-title').focus();
 }
 
-function closeDetails(save) {
-    if (save && currentLi) {
-        var $li = currentLi;
-        $li.find('.dropbtn').text($.trim($('#d-title').val()));
-        $li.find('.dropdate').text($.trim($('#d-date').val()));
-        $li.data('ntitle', $.trim($('#d-ntitle').val()));
-        $li.data('ndate',  $.trim($('#d-ndate').val()));
-        $li.data('desc',   $('#d-desc').val());
-        $li.data('ndesc',  $.trim($('#d-ndesc').val()));
-        renderLinks($li);
+function showCoverPreview(src) {
+    if (src) {
+        $('#tl-cover-preview').attr('src', src).removeAttr('hidden');
+        $('#tl-remove-image').removeAttr('hidden');
+    } else {
+        $('#tl-cover-preview').attr('src', '').attr('hidden', true);
+        $('#tl-remove-image').attr('hidden', true);
     }
-    $('.event').removeClass('editing');
-    $('#event-details').attr('hidden', true);
-    currentLi = null;
 }
 
-///////// renderDetailChips  /////////  chips (with remove) for linked activities in the panel
-function renderDetailChips() {
-    var $box = $('#d-activities').empty();
-    if (!currentLi) return;
-    [['id1', 'name1'], ['id2', 'name2']].forEach(function(p) {
-        var id = currentLi.data(p[0]);
-        if (!id) return;
-        var nm = currentLi.data(p[1]) || ('[' + id + ']');
-        var $chip = $('<span class="d-chip"></span>').text(nm);
-        $('<button title="Remove">&times;</button>').data('slot', p[0]).appendTo($chip);
-        $box.append($chip);
-        if (!currentLi.data(p[1])) {
-            lookupActivityName(id, function(name) {
-                currentLi.data(p[1], name);
-                $chip.contents().first().replaceWith(document.createTextNode(name));
-            });
-        }
-    });
+function saveTimelineModal() {
+    var title = $.trim($('#tl-title').val());
+    if (!title) { LOOMA.alert('Please enter a timeline title.', 5); return; }
+
+    var urlVal = $.trim($('#tl-cover-url').val());
+    if (urlVal) pendingThumb = urlVal;    // a pasted URL overrides
+
+    currentname   = title;
+    timeline.ndn  = $.trim($('#tl-ntitle').val());
+    timeline.thumb = pendingThumb || '';
+    setname(currentname, loginname);
+
+    $('#timeline-modal').attr('hidden', true);
 }
 
-///////// attachActivity  /////////  link a searched activity to the event being edited
-function attachActivity(id, dn) {
-    if (!currentLi) return;
-    if      (!currentLi.data('id1')) { currentLi.data('id1', id); currentLi.data('name1', dn); }
-    else if (!currentLi.data('id2')) { currentLi.data('id2', id); currentLi.data('name2', dn); }
-    else { LOOMA.alert('An event can link at most 2 activities.', 5); return; }
-    renderDetailChips();
+// read a chosen image file, downscale it to a small data-URL (no server upload needed)
+function loadImageToThumb(file, cb) {
+    var reader = new FileReader();
+    reader.onload = function(ev) {
+        var img = new Image();
+        img.onload = function() {
+            var max = 400, w = img.width, h = img.height;
+            if (w > h && w > max)      { h = Math.round(h * max / w); w = max; }
+            else if (h >= w && h > max){ w = Math.round(w * max / h); h = max; }
+            var c = document.createElement('canvas');
+            c.width = w; c.height = h;
+            c.getContext('2d').drawImage(img, 0, 0, w, h);
+            cb(c.toDataURL('image/jpeg', 0.8));
+        };
+        img.src = ev.target.result;
+    };
+    reader.readAsDataURL(file);
 }
 
 
 //////////////////////////////////
-///////   ACTIVITY SEARCH  ////////
+///////     EVENT MODAL    ////////
 //////////////////////////////////
-// displayResults() is the callback invoked by looma-search.js after a search
-function displayResults(results) {
-    var $box = $('#activity-results').empty();
-    var acts = results.list.filter(function(x) { return x.ft !== 'chapter'; });
-    if (!acts.length) { $box.text('No activities found.'); return; }
 
-    acts.forEach(function(item) {
-        var id = (item._id && (item._id.$id || item._id.$oid)) || item._id;
-        var $row = $('<div class="resultitem"></div>');
-        $('<img>').attr('src', LOOMA.thumbnail(item.fn, item.fp, item.ft)).appendTo($row);
-        $('<p class="result_dn"></p>').text(item.dn || '').appendTo($row);
-        $('<button>Add</button>').data('id', id).data('dn', item.dn).appendTo($row);
-        $box.append($row);
-    });
+function openEventModal(index, isNew) {
+    if (isNew) {
+        editingIndex = null;
+        insertIndex  = index;
+        $('#event-modal-title').text('Add Event');
+        $('#ev-delete').attr('hidden', true);
+        $('#ev-title, #ev-ntitle, #ev-date, #ev-ndate, #ev-desc, #ev-ndesc').val('');
+    } else {
+        editingIndex = index;
+        var e = events[index];
+        $('#event-modal-title').text('Edit Event');
+        $('#ev-delete').removeAttr('hidden');
+        $('#ev-title').val(e.title  || '');
+        $('#ev-ntitle').val(e.ndn   || '');
+        $('#ev-date').val(e.date    || '');
+        $('#ev-ndate').val(e.ndate  || '');
+        $('#ev-desc').val(e.desc    || '');
+        $('#ev-ndesc').val(e.ndesc  || '');
+    }
+    $('#event-modal').removeAttr('hidden');
+    $('#ev-title').focus();
+}
+
+function saveEventModal() {
+    var title = $.trim($('#ev-title').val());
+    if (!title) { LOOMA.alert('Please enter an event title.', 5); return; }
+
+    var e = {
+        title: title,
+        ndn:   $.trim($('#ev-ntitle').val()),
+        date:  $.trim($('#ev-date').val()),
+        ndate: $.trim($('#ev-ndate').val()),
+        desc:  $('#ev-desc').val(),
+        ndesc: $.trim($('#ev-ndesc').val())
+    };
+
+    if (editingIndex !== null) events[editingIndex] = e;
+    else                       events.splice(insertIndex, 0, e);
+
+    $('#event-modal').attr('hidden', true);
+    renderTimeline();
+}
+
+function deleteEvent() {
+    if (editingIndex !== null) events.splice(editingIndex, 1);
+    $('#event-modal').attr('hidden', true);
+    renderTimeline();
 }
 
 
@@ -198,10 +201,10 @@ function displayResults(results) {
 
 function editor_clear() {
     setname("");
-    $ol.empty();
-    $ol.removeData('history-id');
-    closeDetails(false);
-    refreshEmptyHint();
+    timeline = { ndn: "", thumb: "" };
+    events = [];
+    $('#timeline-modal, #event-modal').attr('hidden', true);
+    renderTimeline();
     editor_checkpoint();
 }
 
@@ -209,67 +212,66 @@ function editor_checkpoint() { savedSignature = signature(); }
 function editor_modified()   { return (signature() !== savedSignature); }
 
 function signature() {
-    var sig = "";
-    $ol.find('.event').each(function() {
-        var $li = $(this);
-        sig += '|' + $li.find('.dropbtn').text()
-             + '~' + $li.find('.dropdate').text()
-             + '~' + ($li.data('ntitle') || '')
-             + '~' + ($li.data('ndate')  || '')
-             + '~' + ($li.data('desc')   || '')
-             + '~' + ($li.data('ndesc')  || '')
-             + '~' + ($li.data('id1')    || '')
-             + '~' + ($li.data('id2')    || '');
-    });
-    return sig;
+    return JSON.stringify({ n: currentname || '', t: timeline, e: events });
 }
 
-//  pack the events (in current timeline order) into the events[] array for storage
-function editor_pack() {
-    var events = [];
-    $ol.find('.event').each(function() {
-        var $li    = $(this);
-        var title  = $.trim($li.find('.dropbtn').text());
-        var date   = $.trim($li.find('.dropdate').text());
-        var ntitle = $.trim($li.data('ntitle') || '');
-        var ndate  = $.trim($li.data('ndate')  || '');
-        var desc   = $li.data('desc')  || '';
-        var ndesc  = $.trim($li.data('ndesc') || '');
-        var id1    = $li.data('id1') || '';
-        var id2    = $li.data('id2') || '';
-
-        var popup = [desc];
-        if (id1 || id2) popup.push(id1);
-        if (id2)        popup.push(id2);
-
-        var ev = { title: title, date: date, popup: popup };
-        if (ntitle) ev.ndn    = ntitle;
-        if (ndate)  ev.ndate  = ndate;
-        if (ndesc)  ev.npopup = [ndesc];
-        events.push(ev);
+//  pack events into the stored shape
+function packEvents() {
+    return events.map(function(e) {
+        var ev = { title: e.title, date: e.date, popup: [e.desc || ''] };
+        if (e.ndn)   ev.ndn    = e.ndn;
+        if (e.ndate) ev.ndate  = e.ndate;
+        if (e.ndesc) ev.npopup = [e.ndesc];
+        return ev;
     });
-    return events;
 }
 
+//  custom save: savefile() can't carry title/ndn/thumb, so post them directly
 function editor_save(name) {
-    if ($ol.find('.event').length === 0) {
-        LOOMA.alert('Add at least one event before saving.', 5);
-        return;
-    }
-    // savefile(name, collection, filetype, data, activityFlag, author)
-    savefile(name, currentcollection, currentfiletype, editor_pack(), "false", loginname);
-    // activityFlag 'false' - user timelines are NOT indexed as activities (stay out of library search)
+    if (events.length === 0) { LOOMA.alert('Add at least one event before saving.', 5); return; }
+    if (!name) name = currentname;
+
+    $.post("looma-database-utilities.php", {
+        cmd:        "save",
+        collection: "user_histories",
+        db:         currentDB,
+        ft:         "history",
+        activity:   "false",          // NOT indexed as an activity (stays out of library search)
+        dn:         LOOMA.escapeHTML(name),
+        title:      LOOMA.escapeHTML(name),
+        ndn:        timeline.ndn || '',
+        thumb:      timeline.thumb || DEFAULT_THUMB,
+        author:     loginname,
+        editor:     loginname,
+        data:       packEvents()
+    }).then(function() {
+        editor_checkpoint();
+        LOOMA.alert('Timeline "' + name + '" saved', 5);
+    });
 }
 
 // called by filecommands after a File-menu OPEN
 function editor_display(response) {
     editor_clear();
     setname(response.dn || response.title, response.author);
-    if (response['_id']) $ol.data('history-id', response['_id']['$id'] || response['_id']['$oid']);
 
-    var events = response.events || response.data || [];
-    $(events).each(function(i, ev) { addEvent(ev); });
-    refreshEmptyHint();
+    timeline.ndn   = response.ndn   || '';
+    timeline.thumb = response.thumb || '';
+
+    events = (response.events || response.data || []).map(function(ev) {
+        var popup  = ev.popup  || [];
+        var npopup = ev.npopup || [];
+        return {
+            title: ev.title || '',
+            ndn:   ev.ndn   || '',
+            date:  ev.date  || '',
+            ndate: ev.ndate || '',
+            desc:  popup[0] || '',
+            ndesc: npopup[0] || ''
+        };
+    });
+
+    renderTimeline();
     editor_checkpoint();
 }
 
@@ -280,8 +282,6 @@ function quit() {
 
 
 $(document).ready(function() {
-    $ol = $('#timeline-ol');
-
     loginname  = LOOMA.loggedIn();
     loginlevel = LOOMA.readCookie('login-level');
     loginteam  = LOOMA.readCookie('login-team');
@@ -292,11 +292,6 @@ $(document).ready(function() {
     currentfiletype   = "history";
     currentDB         = 'loomalocal';
 
-    // the activity search (#search, inside the details panel) searches ACTIVITIES
-    $('#collection').val('activities');
-    $('#includeLesson').val(false);
-    var image = document.getElementById('image-checkbox'); if (image) image.checked = true;
-
     $('.template-cmd').hide();   // no templates for history timelines
 
     // callbacks expected by looma-filecommands.js
@@ -305,55 +300,46 @@ $(document).ready(function() {
     callbacks['display']    = editor_display;
     callbacks['modified']   = editor_modified;
     callbacks['checkpoint'] = editor_checkpoint;
-    callbacks['new']        = function() { addEvent(); refreshEmptyHint(); editor_checkpoint(); };
+    callbacks['new']        = function() { openTimelineModal(); };
 
-    // + Add Event
-    $('#add-event').on('click', function() {
-        var $li = addEvent();
-        refreshEmptyHint();
-        $('#playground').animate({ scrollLeft: $('#playground')[0].scrollWidth }, 300);
-        $li.find('.dropbtn').focus();
+    // --- timeline surface ---
+    $('#timeline-ol').on('click', '.insert-btn', function() {
+        openEventModal(parseInt($(this).attr('data-index'), 10), true);
     });
-
-    // per-event controls (delegated)
-    $ol.on('click', '.ev-details', function() { openDetails($(this).closest('.event')); return false; });
-    $ol.on('click', '.ev-remove', function() {
-        var $li = $(this).closest('.event');
-        if (currentLi && currentLi[0] === $li[0]) closeDetails(false);
-        $li.remove(); refreshEmptyHint(); return false;
-    });
-    $ol.on('click', '.ev-move-left', function() {
-        var $li = $(this).closest('.event'), $prev = $li.prev('.event');
-        if ($prev.length) $li.insertBefore($prev);
-        return false;
-    });
-    $ol.on('click', '.ev-move-right', function() {
-        var $li = $(this).closest('.event'), $next = $li.next('.event');
-        if ($next.length) $li.insertAfter($next);
-        return false;
+    $('#timeline-ol').on('click', '.event', function() {
+        openEventModal(parseInt($(this).attr('data-index'), 10), false);
     });
 
-    // details panel
-    $('#details-done').on('click',  function() { closeDetails(true); });
-    $('#details-close').on('click', function() { closeDetails(true); });
-    $('#d-link-activity').on('click', function() {
-        $('#activity-search').removeAttr('hidden');
-        $('#search-term').focus();
-    });
-    $('#d-activities').on('click', 'button', function() {
-        var slot = $(this).data('slot');
-        currentLi.removeData(slot).removeData(slot === 'id1' ? 'name1' : 'name2');
-        if (slot === 'id1' && currentLi.data('id2')) {   // keep positions compact
-            currentLi.data('id1', currentLi.data('id2')); currentLi.data('name1', currentLi.data('name2'));
-            currentLi.removeData('id2').removeData('name2');
+    // --- timeline modal ---
+    $('#timeline-details-btn').on('click', openTimelineModal);
+    $('#tl-done').on('click', saveTimelineModal);
+    $('#tl-choose-image').on('click', function() { $('#tl-cover-file').click(); });
+    $('#tl-cover-file').on('change', function() {
+        if (this.files && this.files[0]) {
+            loadImageToThumb(this.files[0], function(dataUrl) {
+                pendingThumb = dataUrl;
+                $('#tl-cover-url').val('');
+                showCoverPreview(dataUrl);
+            });
         }
-        renderDetailChips();
-        return false;
     });
-    $('#activity-results').on('click', 'button', function() {
-        attachActivity($(this).data('id'), $(this).data('dn'));
-        return false;
+    $('#tl-cover-url').on('input', function() {
+        var v = $.trim($(this).val());
+        if (v) { pendingThumb = v; showCoverPreview(v); }
     });
+    $('#tl-remove-image').on('click', function() {
+        pendingThumb = '';
+        $('#tl-cover-url').val('');
+        $('#tl-cover-file').val('');
+        showCoverPreview('');
+    });
+
+    // --- event modal ---
+    $('#ev-done').on('click', saveEventModal);
+    $('#ev-delete').on('click', deleteEvent);
+
+    // close (X) buttons - just hide, no changes applied
+    $('.modal-close').on('click', function() { $('#' + $(this).data('modal')).attr('hidden', true); });
 
     // timeline scroll arrows
     $('#timelineLeft').on('click',  function() { $('#playground').animate({ scrollLeft: '-=300px' }, 500); });
@@ -362,6 +348,9 @@ $(document).ready(function() {
     // dismiss / back -> quit (prompts to save if modified)
     $('#dismiss').off('click').on('click', function() { quit(); });
 
-    refreshEmptyHint();
+    renderTimeline();
     editor_checkpoint();
+
+    // on entry with a fresh timeline, open the Timeline modal first
+    openTimelineModal();
 });

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -92,8 +92,17 @@ function openTimelineModal() {
     $('#tl-cover-url').val('');
     pendingThumb = timeline.thumb || '';
     showCoverPreview(pendingThumb);
-    $('#timeline-modal').removeAttr('hidden');
+    setNepali('tl-nepali', !!timeline.ndn);     // expand only if a Nepali title already exists
+    $('#timeline-modal').addClass('open');
     $('#tl-title').focus();
+}
+
+// show/collapse the Nepali translation fields for a modal
+function setNepali(targetId, expand) {
+    var $fields = $('#' + targetId);
+    var $btn = $('.nepali-toggle[data-target="' + targetId + '"]');
+    if (expand) { $fields.addClass('show');   $btn.html('&minus; Hide Nepali translation'); }
+    else        { $fields.removeClass('show'); $btn.html('&#43; Add Nepali translation'); }
 }
 
 function showCoverPreview(src) {
@@ -118,7 +127,7 @@ function saveTimelineModal() {
     timeline.thumb = pendingThumb || '';
     setname(currentname, loginname);
 
-    $('#timeline-modal').attr('hidden', true);
+    $('#timeline-modal').removeClass('open');
 }
 
 // read a chosen image file, downscale it to a small data-URL (no server upload needed)
@@ -152,6 +161,7 @@ function openEventModal(index, isNew) {
         $('#event-modal-title').text('Add Event');
         $('#ev-delete').attr('hidden', true);
         $('#ev-title, #ev-ntitle, #ev-date, #ev-ndate, #ev-desc, #ev-ndesc').val('');
+        setNepali('ev-nepali', false);
     } else {
         editingIndex = index;
         var e = events[index];
@@ -163,8 +173,9 @@ function openEventModal(index, isNew) {
         $('#ev-ndate').val(e.ndate  || '');
         $('#ev-desc').val(e.desc    || '');
         $('#ev-ndesc').val(e.ndesc  || '');
+        setNepali('ev-nepali', !!(e.ndn || e.ndate || e.ndesc));  // expand only if Nepali content exists
     }
-    $('#event-modal').removeAttr('hidden');
+    $('#event-modal').addClass('open');
     $('#ev-title').focus();
 }
 
@@ -184,13 +195,13 @@ function saveEventModal() {
     if (editingIndex !== null) events[editingIndex] = e;
     else                       events.splice(insertIndex, 0, e);
 
-    $('#event-modal').attr('hidden', true);
+    $('#event-modal').removeClass('open');
     renderTimeline();
 }
 
 function deleteEvent() {
     if (editingIndex !== null) events.splice(editingIndex, 1);
-    $('#event-modal').attr('hidden', true);
+    $('#event-modal').removeClass('open');
     renderTimeline();
 }
 
@@ -203,7 +214,7 @@ function editor_clear() {
     setname("");
     timeline = { ndn: "", thumb: "" };
     events = [];
-    $('#timeline-modal, #event-modal').attr('hidden', true);
+    $('#timeline-modal, #event-modal').removeClass('open');
     renderTimeline();
     editor_checkpoint();
 }
@@ -339,7 +350,13 @@ $(document).ready(function() {
     $('#ev-delete').on('click', deleteEvent);
 
     // close (X) buttons - just hide, no changes applied
-    $('.modal-close').on('click', function() { $('#' + $(this).data('modal')).attr('hidden', true); });
+    $('.modal-close').on('click', function() { $('#' + $(this).data('modal')).removeClass('open'); });
+
+    // Nepali translation toggle (both modals)
+    $('.nepali-toggle').on('click', function() {
+        var t = $(this).data('target');
+        setNepali(t, !$('#' + t).hasClass('show'));
+    });
 
     // timeline scroll arrows
     $('#timelineLeft').on('click',  function() { $('#playground').animate({ scrollLeft: '-=300px' }, 500); });

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -8,13 +8,13 @@ Description: editor for user-created history timelines.
     above/below). Tap a "+" insert slot to add an event, or tap an event to edit it in
     the Event modal (title, date, description, + optional Nepali). No linked activities.
 
-    Data model (in the 'user_histories' collection):
+    Data model (in the 'histories' collection):
         { dn, ft:'history', title, ndn, thumb, events:[ event, ... ] }
     each event:
         { title, date, popup:[description], ndn?, ndate?, npopup:[nepaliDescription]? }
 
-    IMPORTANT: reads/writes ONLY the 'user_histories' collection. The curated, read-only
-    'histories' collection (the 11 approved timelines) is never referenced.
+    IMPORTANT: reads/writes the 'histories' collection, alongside the curated
+    approved timelines.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -244,7 +244,7 @@ function editor_save(name) {
 
     $.post("looma-database-utilities.php", {
         cmd:        "save",
-        collection: "user_histories",
+        collection: "histories",
         db:         currentDB,
         ft:         "history",
         activity:   "false",          // NOT indexed as an activity (stays out of library search)
@@ -297,9 +297,9 @@ $(document).ready(function() {
     loginlevel = LOOMA.readCookie('login-level');
     loginteam  = LOOMA.readCookie('login-team');
 
-    // File commands operate on the user_histories collection ONLY
+    // File commands operate on the histories collection ONLY
     currentname       = "";
-    currentcollection = "user_histories";
+    currentcollection = "histories";
     currentfiletype   = "history";
     currentDB         = 'loomalocal';
 
@@ -323,6 +323,9 @@ $(document).ready(function() {
 
     // --- timeline modal ---
     $('#timeline-details-btn').on('click', openTimelineModal);
+    $('#timeline-save-btn').on('click', function() {
+        savework(currentname, currentcollection, currentfiletype);
+    });
     $('#tl-done').on('click', saveTimelineModal);
     $('#tl-choose-image').on('click', function() { $('#tl-cover-file').click(); });
     $('#tl-cover-file').on('change', function() {

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -1,0 +1,432 @@
+/*
+LOOMA javascript file
+Filename: looma-edit-history.js
+Description: editor for user-created history timelines. Modeled on looma-edit-slideshow.js.
+
+    A timeline is a document in the 'user_histories' collection with this shape:
+        { dn, ft:'history', title, thumb, events: [ event, ... ] }
+    where each event is:
+        { title, date, popup:[description, activityId1, activityId2],
+          ndn(optional), ndate(optional), npopup:[nepaliDescription](optional) }
+    popup[0] is the English description; popup[1]/popup[2] are optional linked activity ids.
+
+    IMPORTANT: this editor reads/writes ONLY the 'user_histories' collection.
+    The curated, read-only 'histories' collection (the 11 approved timelines) is never referenced.
+
+Owner: VillageTech Solutions (villagetechsolutions.org)
+Revision: Looma 7.x
+ */
+
+'use strict';
+
+var savedSignature = "";     //checkpoint of the timeline, for detecting modifications
+var loginname, loginlevel, loginteam;
+var $timeline;               //the #timelineDisplay element
+var activeCard = null;       //the event card currently selected (target for 'Add activity')
+var currentlyPreviewedActivity;
+
+var searchName = 'history-editor-search';   //used by looma-search.js to save/restore search settings
+
+////////////////////////////////////////////
+//////   functions used by filecommands /////
+////////////////////////////////////////////
+
+///////// editor_clear  /////////
+function editor_clear() {
+    setname("");
+    $timeline.empty();
+    $timeline.removeData('thumb').removeData('history-id');
+    activeCard = null;
+    $("#preview").empty().hide();
+    clearFilter();
+    editor_checkpoint();
+}
+
+///////// editor_checkpoint /////////
+function editor_checkpoint() { savedSignature = signature(); }
+
+///////// editor_modified /////////
+function editor_modified() { return (signature() !== savedSignature); }
+
+///////// signature  /////////
+//  build a string that changes whenever any event field changes, so filecommands can detect edits
+function signature() {
+    var sig = ($timeline.data('thumb') || "");
+    $('#timelineDisplay .eventCard').each(function() {
+        var $c = $(this);
+        sig += '|' + $c.find('.ev-date').val()
+             + '~' + $c.find('.ev-ndate').val()
+             + '~' + $c.find('.ev-title').val()
+             + '~' + $c.find('.ev-ntitle').val()
+             + '~' + $c.find('.ev-desc').val()
+             + '~' + $c.find('.ev-ndesc').val()
+             + '~' + ($c.data('id1') || '')
+             + '~' + ($c.data('id2') || '');
+    });
+    return sig;
+}
+
+///////// editor_pack  /////////
+//  pack the event cards (in current DOM/timeline order) into the events[] array for storage
+function editor_pack() {
+    var events = [];
+    $('#timelineDisplay .eventCard').each(function() {
+        var $c = $(this);
+        var title  = $.trim($c.find('.ev-title').val());
+        var ntitle = $.trim($c.find('.ev-ntitle').val());
+        var date   = $.trim($c.find('.ev-date').val());
+        var ndate  = $.trim($c.find('.ev-ndate').val());
+        var desc   = $c.find('.ev-desc').val() || "";
+        var ndesc  = $.trim($c.find('.ev-ndesc').val());
+        var id1    = $c.data('id1') || "";
+        var id2    = $c.data('id2') || "";
+
+        // popup: [description, id1?, id2?]   (keep positions so id2 stays at index 2)
+        var popup = [desc];
+        if (id1 || id2) popup.push(id1);
+        if (id2)        popup.push(id2);
+
+        var ev = { title: title, date: date, popup: popup };
+        if (ntitle) ev.ndn    = ntitle;
+        if (ndate)  ev.ndate  = ndate;
+        if (ndesc)  ev.npopup = [ndesc];
+
+        events.push(ev);
+    });
+    return events;
+}
+
+///////// editor_save  /////////
+function editor_save(name) {
+    if ($('#timelineDisplay .eventCard').length === 0) {
+        LOOMA.alert('Add at least one event before saving.', 5);
+        return;
+    }
+    // savefile(name, collection, filetype, data, activityFlag, author)
+    savefile(name, currentcollection, currentfiletype, editor_pack(), "false", loginname);
+    // NOTE: activityFlag 'false' - user timelines are NOT indexed as activities (stay out of library search)
+}
+
+///////// editor_display  ///////// (called by filecommands after a File-menu OPEN)
+function editor_display(response) {
+    editor_clear();
+    setname(response.dn || response.title, response.author);
+    if (response['_id']) {
+        $timeline.data('history-id', response['_id']['$id'] || response['_id']['$oid']);
+    }
+    if (response.thumb) $timeline.data('thumb', response.thumb);
+
+    var events = response.events || response.data || [];
+    $(events).each(function(index, ev) { addEventCard(ev); });
+
+    makesortable();
+    editor_checkpoint();
+}
+
+// end FILE COMMANDS callbacks
+
+
+//////////////////////////////////
+///////   EVENT CARDS      ////////
+//////////////////////////////////
+
+///////// addEventCard  /////////
+//  create one editable event card and append it to the timeline. ev may be undefined (blank new event).
+function addEventCard(ev) {
+    ev = ev || {};
+    var popup  = ev.popup  || [];
+    var npopup = ev.npopup || [];
+    var desc   = popup[0]  || "";
+    var id1    = popup[1]  || "";
+    var id2    = popup[2]  || "";
+
+    var $card = $(
+        '<div class="eventCard">' +
+        '  <div class="ev-head">' +
+        '     <input class="ev-date"  type="text" placeholder="Date (e.g. 1543)">' +
+        '     <button class="ev-remove" title="Delete this event">&times;</button>' +
+        '  </div>' +
+        '  <input    class="ev-ndate"  type="text" placeholder="मिति (Nepali date - optional)">' +
+        '  <input    class="ev-title"  type="text" placeholder="Event title (English)">' +
+        '  <input    class="ev-ntitle" type="text" placeholder="शीर्षक (Nepali title - optional)">' +
+        '  <textarea class="ev-desc"   placeholder="Description (English)"></textarea>' +
+        '  <textarea class="ev-ndesc"  placeholder="विवरण (Nepali description - optional)"></textarea>' +
+        '  <div class="ev-activities"></div>' +
+        '</div>'
+    );
+
+    $card.find('.ev-date').val(ev.date || "");
+    $card.find('.ev-ndate').val(ev.ndate || "");
+    $card.find('.ev-title').val(ev.title || "");
+    $card.find('.ev-ntitle').val(ev.ndn || "");
+    $card.find('.ev-desc').val(desc);
+    $card.find('.ev-ndesc').val(npopup[0] || "");
+    if (id1) $card.data('id1', id1);
+    if (id2) $card.data('id2', id2);
+
+    $card.appendTo('#timelineDisplay');
+    renderActivitySlots($card);
+    return $card;
+}
+
+///////// renderActivitySlots  /////////
+//  show a chip for each linked activity (id1/id2). Looks up the activity name asynchronously.
+function renderActivitySlots($card) {
+    var $slots = $card.find('.ev-activities').empty();
+    [['id1', 'name1'], ['id2', 'name2']].forEach(function(pair) {
+        var id = $card.data(pair[0]);
+        if (!id) return;
+        var $chip = $('<span class="ev-chip">' +
+                      '<span class="ev-chip-name">activity…</span>' +
+                      '<button class="ev-chip-remove" title="Remove activity">&times;</button>' +
+                      '</span>');
+        $chip.data('slot', pair[0]);
+        $slots.append($chip);
+
+        var cached = $card.data(pair[1]);
+        if (cached) { $chip.find('.ev-chip-name').text(cached); return; }
+
+        // look up the activity display name to show on the chip
+        $.post("looma-database-utilities.php",
+            { cmd: "openByID", collection: "activities", id: id },
+            function(result) {
+                var nm = (result && result.dn) ? result.dn : ('[' + id + ']');
+                $chip.find('.ev-chip-name').text(nm);
+                $card.data(pair[1], nm);
+            }, 'json');
+    });
+}
+
+///////// attachActivityToActiveCard  /////////
+//  called when the user clicks 'Add' on a search result - links that activity to the selected event
+function attachActivityToActiveCard(item) {
+    if (!activeCard || $(activeCard).closest('body').length === 0) {
+        LOOMA.alert('Click an event first, then Add an activity to it.', 5);
+        return;
+    }
+    var id = (item._id && (item._id.$id || item._id.$oid)) || item._id;
+    var $c = $(activeCard);
+
+    if      (!$c.data('id1')) { $c.data('id1', id); $c.data('name1', item.dn); }
+    else if (!$c.data('id2')) { $c.data('id2', id); $c.data('name2', item.dn); }
+    else { LOOMA.alert('An event can link at most 2 activities.', 5); return; }
+
+    renderActivitySlots($c);
+}
+
+///////// setActiveCard  /////////
+function setActiveCard(card) {
+    if (activeCard === card) return;
+    $('#timelineDisplay .eventCard').removeClass('activeCard');
+    activeCard = card;
+    if (card) $(card).addClass('activeCard');
+}
+
+
+//////////////////////////////////
+///////   SEARCH RESULTS   ////////
+//////////////////////////////////
+//  (adapted from looma-edit-slideshow.js - renders the activities search into the results pane)
+
+var clearFilter = function() {
+    if ($('#collection').val() == 'activities') {
+        $('#searchString').val("");
+        $(".filter_dropdown").each(function() { this.selectedIndex = 0; });
+        $(".filter_checkbox").each(function() { $(this).prop("checked", false); });
+        var image = document.getElementById('image-checkbox'); if (image) image.checked = true;
+    }
+    $("#innerResultsMenu").empty();
+    $("#innerResultsDiv").empty();
+    $("#preview").empty();
+};
+
+// displayResults() is the callback invoked by looma-search.js after a search
+function displayResults(results) {
+    var activities = [];
+    for (var i = 0; i < results.list.length; i++) {
+        if (results.list[i]['ft'] !== 'chapter') activities.push(results.list[i]);
+    }
+    $('#innerResultsMenu, #innerResultsDiv').empty();
+
+    var container = document.createElement("div");
+    container.id = "actResultDiv";
+    $('#innerResultsDiv').append(container);
+
+    var title = document.createElement("h5");
+    title.id = "activityTitle";
+    title.innerHTML = "<a class='heading'>Activities (" + activities.length + (activities.length === 1 ? " Result)" : " Results)") + "</a>";
+    container.appendChild(title);
+
+    for (var j = 0; j < activities.length; j++) {
+        container.appendChild(createActivityDiv(activities[j]));
+    }
+}
+
+function thumbnail(item) {
+    if (item.thumb) return item.thumb;
+    return LOOMA.thumbnail(item.fn, item.fp, item.ft);
+}
+
+//  build a search-result row with an Add / Preview button (Delete hidden by CSS)
+function createActivityDiv(item) {
+    var div = document.createElement("div");
+    div.className = "resultitem";
+
+    var activityDiv = document.createElement("div");
+    activityDiv.className = "activityDiv";
+    $(activityDiv).data("id", (item['_id']['$id'] || item['_id']['$oid'] || item['_id']));
+    $(activityDiv).data("type", item['ft']);
+    item.collection = 'activities';
+    $.data(activityDiv, 'mongo', item);
+
+    var thumbnaildiv = document.createElement("div");
+    thumbnaildiv.className = "thumbnaildiv";
+    activityDiv.appendChild(thumbnaildiv);
+    $("<img/>", { class: "resultsimg", src: thumbnail(item) }).appendTo(thumbnaildiv);
+
+    var textdiv = document.createElement("div");
+    textdiv.className = "textdiv";
+    activityDiv.appendChild(textdiv);
+    var dn = item.dn ? item.dn.substring(0, 24) : "";
+    $("<p/>", { class: "result_dn", html: "<b>" + dn + "</b>" }).appendTo(textdiv);
+    if ('ch_id' in item) $("<span/>", { class: "result_ID", html: "[" + item.ch_id + "]" }).appendTo(textdiv);
+
+    var buttondiv = document.createElement("div");
+    buttondiv.className = "buttondiv";
+    activityDiv.appendChild(buttondiv);
+    $("<button/>", { class: "add",     html: "Add" }).appendTo(buttondiv);
+    $("<button/>", { class: "preview", html: "Preview" }).appendTo(buttondiv);
+
+    div.appendChild(activityDiv);
+    return div;
+}
+
+///////// preview_result  /////////
+function preview_result(item) {
+    $('#preview').show();
+    $('#hints, .hint').hide();
+
+    var $mongo   = $(item).data('mongo');
+    var filetype = $(item).data('type');
+    var filename = $mongo.fn;
+    var dataID   = $(item).data('id');
+    var filepath = ('fp' in $mongo) ? $mongo.fp : null;
+
+    if (filetype == "jpg" || filetype == "gif" || filetype == "png" || filetype == "image") {
+        if (!filepath) filepath = '../content/pictures/';
+        document.querySelector("div#preview").innerHTML =
+            '<img src="' + filepath + filename + '" id="displayImage" data-id="' + dataID + '">';
+    } else if (filetype == "text") {
+        $.post("looma-database-utilities.php",
+            { cmd: "openByID", collection: "text", id: $mongo.mongoID ? ($mongo.mongoID.$id || $mongo.mongoID.$oid) : dataID },
+            function(result) { document.querySelector("div#preview").innerHTML = result.data; },
+            'json');
+    } else {
+        document.querySelector("div#preview").innerHTML =
+            "<p class='hint'>No preview for this file type (" + LOOMA.typename(filetype) + ").</p>";
+    }
+}
+
+
+/////////////////////////// SORTABLE UI ////////  requires jQuery UI  ///////////////////
+//  reorder event cards along the timeline by dragging the date bar (.ev-head)
+function makesortable() {
+    $("#timelineDisplay").sortable({
+        opacity: 0.7,
+        axis: "x",
+        scroll: true,
+        handle: ".ev-head"
+    }).disableSelection();
+}
+function refreshsortable() { makesortable(); }
+
+
+///////// quit  ///////// (override so BACK/dismiss prompts to save)
+function quit() {
+    if (callbacks['modified']())
+        savework(currentname, currentcollection, currentfiletype);
+    else
+        window.history.back();
+}
+
+
+$(document).ready(function() {
+    $timeline = $('#timelineDisplay');
+
+    loginname  = LOOMA.loggedIn();
+    loginlevel = LOOMA.readCookie('login-level');
+    loginteam  = LOOMA.readCookie('login-team');
+
+    // File commands operate on the user_histories collection ONLY.
+    currentname       = "";
+    currentcollection = "user_histories";
+    currentfiletype   = "history";
+    currentDB         = 'loomalocal';   // File->New content is user/local content (matches other editors)
+
+    // the content search bar (#search) searches ACTIVITIES, for linking into events
+    $('#collection').val('activities');
+    $('#includeLesson').val(false);
+    var image = document.getElementById('image-checkbox'); if (image) image.checked = true;
+
+    $('.template-cmd').hide();   // no templates for history timelines
+
+    // callbacks expected by looma-filecommands.js
+    callbacks['clear']      = editor_clear;
+    callbacks['save']       = editor_save;
+    callbacks['display']    = editor_display;
+    callbacks['modified']   = editor_modified;
+    callbacks['checkpoint'] = editor_checkpoint;
+    callbacks['new']        = function() { addEventCard(); makesortable(); editor_checkpoint(); };
+    // 'quit' overridden below via #dismiss / back-button
+
+    // + Add Event
+    $('#add-event').on('click', function() {
+        var $card = addEventCard();
+        makesortable();
+        setActiveCard($card[0]);
+        $('#timeline').animate({ scrollLeft: $('#timeline')[0].scrollWidth }, 300);
+        $card.find('.ev-date').focus();
+    });
+
+    // selecting / removing event cards
+    $('#timelineDisplay').on('mousedown focusin', '.eventCard', function() { setActiveCard(this); });
+    $('#timelineDisplay').on('click', '.ev-remove', function() {
+        var $card = $(this).closest('.eventCard');
+        if ($card[0] === activeCard) setActiveCard(null);
+        $card.remove();
+        return false;
+    });
+    // remove a linked activity chip
+    $('#timelineDisplay').on('click', '.ev-chip-remove', function() {
+        var $chip = $(this).closest('.ev-chip');
+        var $card = $chip.closest('.eventCard');
+        var slot  = $chip.data('slot');
+        $card.removeData(slot).removeData(slot === 'id1' ? 'name1' : 'name2');
+        // if id1 removed but id2 exists, promote id2 -> id1 so positions stay compact
+        if (slot === 'id1' && $card.data('id2')) {
+            $card.data('id1', $card.data('id2')); $card.data('name1', $card.data('name2'));
+            $card.removeData('id2').removeData('name2');
+        }
+        renderActivitySlots($card);
+        return false;
+    });
+
+    // search-result buttons: Add -> link to active event; Preview -> show in preview panel
+    $('#innerResultsDiv').on('click', '.add', function() {
+        attachActivityToActiveCard($(this).closest('.activityDiv').data('mongo'));
+        return false;
+    });
+    $('#innerResultsDiv').on('click', '.preview, .resultsimg', function() {
+        preview_result($(this).closest('.activityDiv'));
+        return false;
+    });
+
+    // timeline scroll arrows
+    $('#timelineLeft').on('click',  function() { $('#timeline').animate({ scrollLeft: '-=250px' }, 500); });
+    $('#timelineRight').on('click', function() { $('#timeline').animate({ scrollLeft: '+=250px' }, 500); });
+
+    // dismiss / back -> quit (prompts to save if modified)
+    $('#dismiss').off('click').click(function() { quit(); });
+
+    editor_checkpoint();
+});

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -1,17 +1,22 @@
 /*
 LOOMA javascript file
 Filename: looma-edit-history.js
-Description: editor for user-created history timelines. Modeled on looma-edit-slideshow.js.
+Description: editor for user-created history timelines.
 
-    A timeline is a document in the 'user_histories' collection with this shape:
-        { dn, ft:'history', title, thumb, events: [ event, ... ] }
-    where each event is:
-        { title, date, popup:[description, activityId1, activityId2],
-          ndn(optional), ndate(optional), npopup:[nepaliDescription](optional) }
-    popup[0] is the English description; popup[1]/popup[2] are optional linked activity ids.
+    The editing surface mirrors the read-only viewer (looma-history.php): a horizontal timeline
+    with events alternating above/below a line. Each event's TITLE and DATE are edited in place
+    (tap and type). Everything else - Nepali title/date, description, and up to two linked
+    activities - is edited in a per-event details panel (the pencil button).
 
-    IMPORTANT: this editor reads/writes ONLY the 'user_histories' collection.
-    The curated, read-only 'histories' collection (the 11 approved timelines) is never referenced.
+    A timeline is a document in the 'user_histories' collection:
+        { dn, ft:'history', title, events: [ event, ... ] }
+    each event:
+        { title, date, popup:[description, activityId1?, activityId2?],
+          ndn?, ndate?, npopup:[nepaliDescription]? }
+
+    IMPORTANT: this editor reads/writes ONLY the 'user_histories' collection. The curated,
+    read-only 'histories' collection (the 11 approved timelines) is never referenced.
+    File-menu / save-load / activity-search flow follows the Slideshow-editor patterns.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -19,69 +24,220 @@ Revision: Looma 7.x
 
 'use strict';
 
-var savedSignature = "";     //checkpoint of the timeline, for detecting modifications
+var savedSignature = "";     //checkpoint for detecting modifications
 var loginname, loginlevel, loginteam;
-var $timeline;               //the #timelineDisplay element
-var activeCard = null;       //the event card currently selected (target for 'Add activity')
-var currentlyPreviewedActivity;
+var $ol;                     //the #timeline-ol element
+var currentLi = null;        //the event whose details panel is open
 
-var searchName = 'history-editor-search';   //used by looma-search.js to save/restore search settings
+var searchName = 'history-editor-search';   //used by looma-search.js
 
-////////////////////////////////////////////
-//////   functions used by filecommands /////
-////////////////////////////////////////////
+//////////////////////////////////
+///////   EVENT TIMELINE   ////////
+//////////////////////////////////
 
-///////// editor_clear  /////////
+///////// buildEventLi  /////////  create one editable event; ev may be undefined (blank)
+function buildEventLi(ev) {
+    ev = ev || {};
+    var popup  = ev.popup  || [];
+    var npopup = ev.npopup || [];
+
+    var $li = $(
+        '<li class="event">' +
+          '<div class="timeline-description">' +
+            '<div class="event-controls">' +
+              '<button class="ev-move-left"  title="Move earlier">&#8249;</button>' +
+              '<button class="ev-details"    title="Edit description / Nepali / activities">&#9998;</button>' +
+              '<button class="ev-remove"     title="Delete event">&times;</button>' +
+              '<button class="ev-move-right" title="Move later">&#8250;</button>' +
+            '</div>' +
+            '<div class="dropbtn"  contenteditable="true" data-placeholder="Event title"></div>' +
+            '<div class="dropdate" contenteditable="true" data-placeholder="Date"></div>' +
+            '<div class="ev-links"></div>' +
+          '</div>' +
+        '</li>'
+    );
+
+    $li.find('.dropbtn').text(ev.title || '');
+    $li.find('.dropdate').text(ev.date || '');
+    $li.data('ntitle', ev.ndn   || '');
+    $li.data('ndate',  ev.ndate || '');
+    $li.data('desc',   popup[0]  || '');
+    $li.data('ndesc',  npopup[0] || '');
+    if (popup[1]) $li.data('id1', popup[1]);
+    if (popup[2]) $li.data('id2', popup[2]);
+
+    renderLinks($li);
+    return $li;
+}
+
+///////// addEvent  /////////
+function addEvent(ev) {
+    var $li = buildEventLi(ev);
+    $ol.append($li);
+    return $li;
+}
+
+///////// refreshEmptyHint  /////////
+function refreshEmptyHint() {
+    $('#empty-hint').toggle($ol.find('.event').length === 0);
+}
+
+///////// renderLinks  /////////  show a chip per linked activity on the event
+function renderLinks($li) {
+    var $links = $li.find('.ev-links').empty();
+    [['id1', 'name1'], ['id2', 'name2']].forEach(function(p) {
+        var id = $li.data(p[0]);
+        if (!id) return;
+        var $chip = $('<span class="ev-link-chip">activity&hellip;</span>');
+        $links.append($chip);
+        var nm = $li.data(p[1]);
+        if (nm) { $chip.text('▶ ' + nm); return; }
+        lookupActivityName(id, function(name) { $li.data(p[1], name); $chip.text('▶ ' + name); });
+    });
+}
+
+///////// lookupActivityName  /////////
+function lookupActivityName(id, cb) {
+    $.post('looma-database-utilities.php',
+        { cmd: 'openByID', collection: 'activities', id: id },
+        function(r) { cb((r && r.dn) ? r.dn : ('[' + id + ']')); }, 'json');
+}
+
+
+//////////////////////////////////
+///////   DETAILS PANEL    ////////
+//////////////////////////////////
+
+function openDetails($li) {
+    currentLi = $li;
+    $('.event').removeClass('editing');
+    $li.addClass('editing');
+
+    $('#d-title').val($li.find('.dropbtn').text());
+    $('#d-ntitle').val($li.data('ntitle') || '');
+    $('#d-date').val($li.find('.dropdate').text());
+    $('#d-ndate').val($li.data('ndate') || '');
+    $('#d-desc').val($li.data('desc') || '');
+    $('#d-ndesc').val($li.data('ndesc') || '');
+
+    renderDetailChips();
+    $('#activity-search').attr('hidden', true);
+    $('#event-details').removeAttr('hidden');
+    $('#d-title').focus();
+}
+
+function closeDetails(save) {
+    if (save && currentLi) {
+        var $li = currentLi;
+        $li.find('.dropbtn').text($.trim($('#d-title').val()));
+        $li.find('.dropdate').text($.trim($('#d-date').val()));
+        $li.data('ntitle', $.trim($('#d-ntitle').val()));
+        $li.data('ndate',  $.trim($('#d-ndate').val()));
+        $li.data('desc',   $('#d-desc').val());
+        $li.data('ndesc',  $.trim($('#d-ndesc').val()));
+        renderLinks($li);
+    }
+    $('.event').removeClass('editing');
+    $('#event-details').attr('hidden', true);
+    currentLi = null;
+}
+
+///////// renderDetailChips  /////////  chips (with remove) for linked activities in the panel
+function renderDetailChips() {
+    var $box = $('#d-activities').empty();
+    if (!currentLi) return;
+    [['id1', 'name1'], ['id2', 'name2']].forEach(function(p) {
+        var id = currentLi.data(p[0]);
+        if (!id) return;
+        var nm = currentLi.data(p[1]) || ('[' + id + ']');
+        var $chip = $('<span class="d-chip"></span>').text(nm);
+        $('<button title="Remove">&times;</button>').data('slot', p[0]).appendTo($chip);
+        $box.append($chip);
+        if (!currentLi.data(p[1])) {
+            lookupActivityName(id, function(name) {
+                currentLi.data(p[1], name);
+                $chip.contents().first().replaceWith(document.createTextNode(name));
+            });
+        }
+    });
+}
+
+///////// attachActivity  /////////  link a searched activity to the event being edited
+function attachActivity(id, dn) {
+    if (!currentLi) return;
+    if      (!currentLi.data('id1')) { currentLi.data('id1', id); currentLi.data('name1', dn); }
+    else if (!currentLi.data('id2')) { currentLi.data('id2', id); currentLi.data('name2', dn); }
+    else { LOOMA.alert('An event can link at most 2 activities.', 5); return; }
+    renderDetailChips();
+}
+
+
+//////////////////////////////////
+///////   ACTIVITY SEARCH  ////////
+//////////////////////////////////
+// displayResults() is the callback invoked by looma-search.js after a search
+function displayResults(results) {
+    var $box = $('#activity-results').empty();
+    var acts = results.list.filter(function(x) { return x.ft !== 'chapter'; });
+    if (!acts.length) { $box.text('No activities found.'); return; }
+
+    acts.forEach(function(item) {
+        var id = (item._id && (item._id.$id || item._id.$oid)) || item._id;
+        var $row = $('<div class="resultitem"></div>');
+        $('<img>').attr('src', LOOMA.thumbnail(item.fn, item.fp, item.ft)).appendTo($row);
+        $('<p class="result_dn"></p>').text(item.dn || '').appendTo($row);
+        $('<button>Add</button>').data('id', id).data('dn', item.dn).appendTo($row);
+        $box.append($row);
+    });
+}
+
+
+//////////////////////////////////
+///////   FILE COMMANDS    ////////
+//////////////////////////////////
+
 function editor_clear() {
     setname("");
-    $timeline.empty();
-    $timeline.removeData('thumb').removeData('history-id');
-    activeCard = null;
-    $("#preview").empty().hide();
-    clearFilter();
+    $ol.empty();
+    $ol.removeData('history-id');
+    closeDetails(false);
+    refreshEmptyHint();
     editor_checkpoint();
 }
 
-///////// editor_checkpoint /////////
 function editor_checkpoint() { savedSignature = signature(); }
+function editor_modified()   { return (signature() !== savedSignature); }
 
-///////// editor_modified /////////
-function editor_modified() { return (signature() !== savedSignature); }
-
-///////// signature  /////////
-//  build a string that changes whenever any event field changes, so filecommands can detect edits
 function signature() {
-    var sig = ($timeline.data('thumb') || "");
-    $('#timelineDisplay .eventCard').each(function() {
-        var $c = $(this);
-        sig += '|' + $c.find('.ev-date').val()
-             + '~' + $c.find('.ev-ndate').val()
-             + '~' + $c.find('.ev-title').val()
-             + '~' + $c.find('.ev-ntitle').val()
-             + '~' + $c.find('.ev-desc').val()
-             + '~' + $c.find('.ev-ndesc').val()
-             + '~' + ($c.data('id1') || '')
-             + '~' + ($c.data('id2') || '');
+    var sig = "";
+    $ol.find('.event').each(function() {
+        var $li = $(this);
+        sig += '|' + $li.find('.dropbtn').text()
+             + '~' + $li.find('.dropdate').text()
+             + '~' + ($li.data('ntitle') || '')
+             + '~' + ($li.data('ndate')  || '')
+             + '~' + ($li.data('desc')   || '')
+             + '~' + ($li.data('ndesc')  || '')
+             + '~' + ($li.data('id1')    || '')
+             + '~' + ($li.data('id2')    || '');
     });
     return sig;
 }
 
-///////// editor_pack  /////////
-//  pack the event cards (in current DOM/timeline order) into the events[] array for storage
+//  pack the events (in current timeline order) into the events[] array for storage
 function editor_pack() {
     var events = [];
-    $('#timelineDisplay .eventCard').each(function() {
-        var $c = $(this);
-        var title  = $.trim($c.find('.ev-title').val());
-        var ntitle = $.trim($c.find('.ev-ntitle').val());
-        var date   = $.trim($c.find('.ev-date').val());
-        var ndate  = $.trim($c.find('.ev-ndate').val());
-        var desc   = $c.find('.ev-desc').val() || "";
-        var ndesc  = $.trim($c.find('.ev-ndesc').val());
-        var id1    = $c.data('id1') || "";
-        var id2    = $c.data('id2') || "";
+    $ol.find('.event').each(function() {
+        var $li    = $(this);
+        var title  = $.trim($li.find('.dropbtn').text());
+        var date   = $.trim($li.find('.dropdate').text());
+        var ntitle = $.trim($li.data('ntitle') || '');
+        var ndate  = $.trim($li.data('ndate')  || '');
+        var desc   = $li.data('desc')  || '';
+        var ndesc  = $.trim($li.data('ndesc') || '');
+        var id1    = $li.data('id1') || '';
+        var id2    = $li.data('id2') || '';
 
-        // popup: [description, id1?, id2?]   (keep positions so id2 stays at index 2)
         var popup = [desc];
         if (id1 || id2) popup.push(id1);
         if (id2)        popup.push(id2);
@@ -90,280 +246,53 @@ function editor_pack() {
         if (ntitle) ev.ndn    = ntitle;
         if (ndate)  ev.ndate  = ndate;
         if (ndesc)  ev.npopup = [ndesc];
-
         events.push(ev);
     });
     return events;
 }
 
-///////// editor_save  /////////
 function editor_save(name) {
-    if ($('#timelineDisplay .eventCard').length === 0) {
+    if ($ol.find('.event').length === 0) {
         LOOMA.alert('Add at least one event before saving.', 5);
         return;
     }
     // savefile(name, collection, filetype, data, activityFlag, author)
     savefile(name, currentcollection, currentfiletype, editor_pack(), "false", loginname);
-    // NOTE: activityFlag 'false' - user timelines are NOT indexed as activities (stay out of library search)
+    // activityFlag 'false' - user timelines are NOT indexed as activities (stay out of library search)
 }
 
-///////// editor_display  ///////// (called by filecommands after a File-menu OPEN)
+// called by filecommands after a File-menu OPEN
 function editor_display(response) {
     editor_clear();
     setname(response.dn || response.title, response.author);
-    if (response['_id']) {
-        $timeline.data('history-id', response['_id']['$id'] || response['_id']['$oid']);
-    }
-    if (response.thumb) $timeline.data('thumb', response.thumb);
+    if (response['_id']) $ol.data('history-id', response['_id']['$id'] || response['_id']['$oid']);
 
     var events = response.events || response.data || [];
-    $(events).each(function(index, ev) { addEventCard(ev); });
-
-    makesortable();
+    $(events).each(function(i, ev) { addEvent(ev); });
+    refreshEmptyHint();
     editor_checkpoint();
 }
 
-// end FILE COMMANDS callbacks
-
-
-//////////////////////////////////
-///////   EVENT CARDS      ////////
-//////////////////////////////////
-
-///////// addEventCard  /////////
-//  create one editable event card and append it to the timeline. ev may be undefined (blank new event).
-function addEventCard(ev) {
-    ev = ev || {};
-    var popup  = ev.popup  || [];
-    var npopup = ev.npopup || [];
-    var desc   = popup[0]  || "";
-    var id1    = popup[1]  || "";
-    var id2    = popup[2]  || "";
-
-    var $card = $(
-        '<div class="eventCard">' +
-        '  <div class="ev-head">' +
-        '     <input class="ev-date"  type="text" placeholder="Date (e.g. 1543)">' +
-        '     <button class="ev-remove" title="Delete this event">&times;</button>' +
-        '  </div>' +
-        '  <input    class="ev-ndate"  type="text" placeholder="मिति (Nepali date - optional)">' +
-        '  <input    class="ev-title"  type="text" placeholder="Event title (English)">' +
-        '  <input    class="ev-ntitle" type="text" placeholder="शीर्षक (Nepali title - optional)">' +
-        '  <textarea class="ev-desc"   placeholder="Description (English)"></textarea>' +
-        '  <textarea class="ev-ndesc"  placeholder="विवरण (Nepali description - optional)"></textarea>' +
-        '  <div class="ev-activities"></div>' +
-        '</div>'
-    );
-
-    $card.find('.ev-date').val(ev.date || "");
-    $card.find('.ev-ndate').val(ev.ndate || "");
-    $card.find('.ev-title').val(ev.title || "");
-    $card.find('.ev-ntitle').val(ev.ndn || "");
-    $card.find('.ev-desc').val(desc);
-    $card.find('.ev-ndesc').val(npopup[0] || "");
-    if (id1) $card.data('id1', id1);
-    if (id2) $card.data('id2', id2);
-
-    $card.appendTo('#timelineDisplay');
-    renderActivitySlots($card);
-    return $card;
-}
-
-///////// renderActivitySlots  /////////
-//  show a chip for each linked activity (id1/id2). Looks up the activity name asynchronously.
-function renderActivitySlots($card) {
-    var $slots = $card.find('.ev-activities').empty();
-    [['id1', 'name1'], ['id2', 'name2']].forEach(function(pair) {
-        var id = $card.data(pair[0]);
-        if (!id) return;
-        var $chip = $('<span class="ev-chip">' +
-                      '<span class="ev-chip-name">activity…</span>' +
-                      '<button class="ev-chip-remove" title="Remove activity">&times;</button>' +
-                      '</span>');
-        $chip.data('slot', pair[0]);
-        $slots.append($chip);
-
-        var cached = $card.data(pair[1]);
-        if (cached) { $chip.find('.ev-chip-name').text(cached); return; }
-
-        // look up the activity display name to show on the chip
-        $.post("looma-database-utilities.php",
-            { cmd: "openByID", collection: "activities", id: id },
-            function(result) {
-                var nm = (result && result.dn) ? result.dn : ('[' + id + ']');
-                $chip.find('.ev-chip-name').text(nm);
-                $card.data(pair[1], nm);
-            }, 'json');
-    });
-}
-
-///////// attachActivityToActiveCard  /////////
-//  called when the user clicks 'Add' on a search result - links that activity to the selected event
-function attachActivityToActiveCard(item) {
-    if (!activeCard || $(activeCard).closest('body').length === 0) {
-        LOOMA.alert('Click an event first, then Add an activity to it.', 5);
-        return;
-    }
-    var id = (item._id && (item._id.$id || item._id.$oid)) || item._id;
-    var $c = $(activeCard);
-
-    if      (!$c.data('id1')) { $c.data('id1', id); $c.data('name1', item.dn); }
-    else if (!$c.data('id2')) { $c.data('id2', id); $c.data('name2', item.dn); }
-    else { LOOMA.alert('An event can link at most 2 activities.', 5); return; }
-
-    renderActivitySlots($c);
-}
-
-///////// setActiveCard  /////////
-function setActiveCard(card) {
-    if (activeCard === card) return;
-    $('#timelineDisplay .eventCard').removeClass('activeCard');
-    activeCard = card;
-    if (card) $(card).addClass('activeCard');
-}
-
-
-//////////////////////////////////
-///////   SEARCH RESULTS   ////////
-//////////////////////////////////
-//  (adapted from looma-edit-slideshow.js - renders the activities search into the results pane)
-
-var clearFilter = function() {
-    if ($('#collection').val() == 'activities') {
-        $('#searchString').val("");
-        $(".filter_dropdown").each(function() { this.selectedIndex = 0; });
-        $(".filter_checkbox").each(function() { $(this).prop("checked", false); });
-        var image = document.getElementById('image-checkbox'); if (image) image.checked = true;
-    }
-    $("#innerResultsMenu").empty();
-    $("#innerResultsDiv").empty();
-    $("#preview").empty();
-};
-
-// displayResults() is the callback invoked by looma-search.js after a search
-function displayResults(results) {
-    var activities = [];
-    for (var i = 0; i < results.list.length; i++) {
-        if (results.list[i]['ft'] !== 'chapter') activities.push(results.list[i]);
-    }
-    $('#innerResultsMenu, #innerResultsDiv').empty();
-
-    var container = document.createElement("div");
-    container.id = "actResultDiv";
-    $('#innerResultsDiv').append(container);
-
-    var title = document.createElement("h5");
-    title.id = "activityTitle";
-    title.innerHTML = "<a class='heading'>Activities (" + activities.length + (activities.length === 1 ? " Result)" : " Results)") + "</a>";
-    container.appendChild(title);
-
-    for (var j = 0; j < activities.length; j++) {
-        container.appendChild(createActivityDiv(activities[j]));
-    }
-}
-
-function thumbnail(item) {
-    if (item.thumb) return item.thumb;
-    return LOOMA.thumbnail(item.fn, item.fp, item.ft);
-}
-
-//  build a search-result row with an Add / Preview button (Delete hidden by CSS)
-function createActivityDiv(item) {
-    var div = document.createElement("div");
-    div.className = "resultitem";
-
-    var activityDiv = document.createElement("div");
-    activityDiv.className = "activityDiv";
-    $(activityDiv).data("id", (item['_id']['$id'] || item['_id']['$oid'] || item['_id']));
-    $(activityDiv).data("type", item['ft']);
-    item.collection = 'activities';
-    $.data(activityDiv, 'mongo', item);
-
-    var thumbnaildiv = document.createElement("div");
-    thumbnaildiv.className = "thumbnaildiv";
-    activityDiv.appendChild(thumbnaildiv);
-    $("<img/>", { class: "resultsimg", src: thumbnail(item) }).appendTo(thumbnaildiv);
-
-    var textdiv = document.createElement("div");
-    textdiv.className = "textdiv";
-    activityDiv.appendChild(textdiv);
-    var dn = item.dn ? item.dn.substring(0, 24) : "";
-    $("<p/>", { class: "result_dn", html: "<b>" + dn + "</b>" }).appendTo(textdiv);
-    if ('ch_id' in item) $("<span/>", { class: "result_ID", html: "[" + item.ch_id + "]" }).appendTo(textdiv);
-
-    var buttondiv = document.createElement("div");
-    buttondiv.className = "buttondiv";
-    activityDiv.appendChild(buttondiv);
-    $("<button/>", { class: "add",     html: "Add" }).appendTo(buttondiv);
-    $("<button/>", { class: "preview", html: "Preview" }).appendTo(buttondiv);
-
-    div.appendChild(activityDiv);
-    return div;
-}
-
-///////// preview_result  /////////
-function preview_result(item) {
-    $('#preview').show();
-    $('#hints, .hint').hide();
-
-    var $mongo   = $(item).data('mongo');
-    var filetype = $(item).data('type');
-    var filename = $mongo.fn;
-    var dataID   = $(item).data('id');
-    var filepath = ('fp' in $mongo) ? $mongo.fp : null;
-
-    if (filetype == "jpg" || filetype == "gif" || filetype == "png" || filetype == "image") {
-        if (!filepath) filepath = '../content/pictures/';
-        document.querySelector("div#preview").innerHTML =
-            '<img src="' + filepath + filename + '" id="displayImage" data-id="' + dataID + '">';
-    } else if (filetype == "text") {
-        $.post("looma-database-utilities.php",
-            { cmd: "openByID", collection: "text", id: $mongo.mongoID ? ($mongo.mongoID.$id || $mongo.mongoID.$oid) : dataID },
-            function(result) { document.querySelector("div#preview").innerHTML = result.data; },
-            'json');
-    } else {
-        document.querySelector("div#preview").innerHTML =
-            "<p class='hint'>No preview for this file type (" + LOOMA.typename(filetype) + ").</p>";
-    }
-}
-
-
-/////////////////////////// SORTABLE UI ////////  requires jQuery UI  ///////////////////
-//  reorder event cards along the timeline by dragging the date bar (.ev-head)
-function makesortable() {
-    $("#timelineDisplay").sortable({
-        opacity: 0.7,
-        axis: "x",
-        scroll: true,
-        handle: ".ev-head"
-    }).disableSelection();
-}
-function refreshsortable() { makesortable(); }
-
-
-///////// quit  ///////// (override so BACK/dismiss prompts to save)
 function quit() {
-    if (callbacks['modified']())
-        savework(currentname, currentcollection, currentfiletype);
-    else
-        window.history.back();
+    if (callbacks['modified']()) savework(currentname, currentcollection, currentfiletype);
+    else window.history.back();
 }
 
 
 $(document).ready(function() {
-    $timeline = $('#timelineDisplay');
+    $ol = $('#timeline-ol');
 
     loginname  = LOOMA.loggedIn();
     loginlevel = LOOMA.readCookie('login-level');
     loginteam  = LOOMA.readCookie('login-team');
 
-    // File commands operate on the user_histories collection ONLY.
+    // File commands operate on the user_histories collection ONLY
     currentname       = "";
     currentcollection = "user_histories";
     currentfiletype   = "history";
-    currentDB         = 'loomalocal';   // File->New content is user/local content (matches other editors)
+    currentDB         = 'loomalocal';
 
-    // the content search bar (#search) searches ACTIVITIES, for linking into events
+    // the activity search (#search, inside the details panel) searches ACTIVITIES
     $('#collection').val('activities');
     $('#includeLesson').val(false);
     var image = document.getElementById('image-checkbox'); if (image) image.checked = true;
@@ -376,57 +305,63 @@ $(document).ready(function() {
     callbacks['display']    = editor_display;
     callbacks['modified']   = editor_modified;
     callbacks['checkpoint'] = editor_checkpoint;
-    callbacks['new']        = function() { addEventCard(); makesortable(); editor_checkpoint(); };
-    // 'quit' overridden below via #dismiss / back-button
+    callbacks['new']        = function() { addEvent(); refreshEmptyHint(); editor_checkpoint(); };
 
     // + Add Event
     $('#add-event').on('click', function() {
-        var $card = addEventCard();
-        makesortable();
-        setActiveCard($card[0]);
-        $('#timeline').animate({ scrollLeft: $('#timeline')[0].scrollWidth }, 300);
-        $card.find('.ev-date').focus();
+        var $li = addEvent();
+        refreshEmptyHint();
+        $('#playground').animate({ scrollLeft: $('#playground')[0].scrollWidth }, 300);
+        $li.find('.dropbtn').focus();
     });
 
-    // selecting / removing event cards
-    $('#timelineDisplay').on('mousedown focusin', '.eventCard', function() { setActiveCard(this); });
-    $('#timelineDisplay').on('click', '.ev-remove', function() {
-        var $card = $(this).closest('.eventCard');
-        if ($card[0] === activeCard) setActiveCard(null);
-        $card.remove();
+    // per-event controls (delegated)
+    $ol.on('click', '.ev-details', function() { openDetails($(this).closest('.event')); return false; });
+    $ol.on('click', '.ev-remove', function() {
+        var $li = $(this).closest('.event');
+        if (currentLi && currentLi[0] === $li[0]) closeDetails(false);
+        $li.remove(); refreshEmptyHint(); return false;
+    });
+    $ol.on('click', '.ev-move-left', function() {
+        var $li = $(this).closest('.event'), $prev = $li.prev('.event');
+        if ($prev.length) $li.insertBefore($prev);
         return false;
     });
-    // remove a linked activity chip
-    $('#timelineDisplay').on('click', '.ev-chip-remove', function() {
-        var $chip = $(this).closest('.ev-chip');
-        var $card = $chip.closest('.eventCard');
-        var slot  = $chip.data('slot');
-        $card.removeData(slot).removeData(slot === 'id1' ? 'name1' : 'name2');
-        // if id1 removed but id2 exists, promote id2 -> id1 so positions stay compact
-        if (slot === 'id1' && $card.data('id2')) {
-            $card.data('id1', $card.data('id2')); $card.data('name1', $card.data('name2'));
-            $card.removeData('id2').removeData('name2');
+    $ol.on('click', '.ev-move-right', function() {
+        var $li = $(this).closest('.event'), $next = $li.next('.event');
+        if ($next.length) $li.insertAfter($next);
+        return false;
+    });
+
+    // details panel
+    $('#details-done').on('click',  function() { closeDetails(true); });
+    $('#details-close').on('click', function() { closeDetails(true); });
+    $('#d-link-activity').on('click', function() {
+        $('#activity-search').removeAttr('hidden');
+        $('#search-term').focus();
+    });
+    $('#d-activities').on('click', 'button', function() {
+        var slot = $(this).data('slot');
+        currentLi.removeData(slot).removeData(slot === 'id1' ? 'name1' : 'name2');
+        if (slot === 'id1' && currentLi.data('id2')) {   // keep positions compact
+            currentLi.data('id1', currentLi.data('id2')); currentLi.data('name1', currentLi.data('name2'));
+            currentLi.removeData('id2').removeData('name2');
         }
-        renderActivitySlots($card);
+        renderDetailChips();
         return false;
     });
-
-    // search-result buttons: Add -> link to active event; Preview -> show in preview panel
-    $('#innerResultsDiv').on('click', '.add', function() {
-        attachActivityToActiveCard($(this).closest('.activityDiv').data('mongo'));
-        return false;
-    });
-    $('#innerResultsDiv').on('click', '.preview, .resultsimg', function() {
-        preview_result($(this).closest('.activityDiv'));
+    $('#activity-results').on('click', 'button', function() {
+        attachActivity($(this).data('id'), $(this).data('dn'));
         return false;
     });
 
     // timeline scroll arrows
-    $('#timelineLeft').on('click',  function() { $('#timeline').animate({ scrollLeft: '-=250px' }, 500); });
-    $('#timelineRight').on('click', function() { $('#timeline').animate({ scrollLeft: '+=250px' }, 500); });
+    $('#timelineLeft').on('click',  function() { $('#playground').animate({ scrollLeft: '-=300px' }, 500); });
+    $('#timelineRight').on('click', function() { $('#playground').animate({ scrollLeft: '+=300px' }, 500); });
 
     // dismiss / back -> quit (prompts to save if modified)
-    $('#dismiss').off('click').click(function() { quit(); });
+    $('#dismiss').off('click').on('click', function() { quit(); });
 
+    refreshEmptyHint();
     editor_checkpoint();
 });

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -11,7 +11,8 @@ Description: editor for user-created history timelines.
     Data model (in the 'histories' collection):
         { dn, ft:'history', title, ndn, thumb, events:[ event, ... ] }
     each event:
-        { title, date, popup:[description], ndn?, ndate?, npopup:[nepaliDescription]? }
+        { title, date, popup:[description], ndn?, ndate?, npopup:[nepaliDescription]?, images?:[url,...] }
+        images: up to 2 Looma-Library image URLs, rendered inline in the viewer's popup.
 
     IMPORTANT: reads/writes the 'histories' collection, alongside the curated
     approved timelines.
@@ -29,11 +30,12 @@ var savedSignature = "";
 
 // --- source of truth ---
 var timeline = { ndn: "", thumb: "" };   // title is kept in `currentname` (the File-menu name)
-var events = [];                          // array of {title, ndn, date, ndate, desc, ndesc}
+var events = [];                          // array of {title, ndn, date, ndate, desc, ndesc, images:[url,...]}
 
 var editingIndex = null;                  // event index being edited (null => creating new)
 var insertIndex  = 0;                     // where a new event will be inserted
 var pendingThumb = "";                    // cover image chosen in the Timeline modal (data-URL or url)
+var eventImages  = [];                    // up to 2 Library image URLs for the event being edited
 
 
 //////////////////////////////////
@@ -41,7 +43,9 @@ var pendingThumb = "";                    // cover image chosen in the Timeline 
 //////////////////////////////////
 
 function renderTimeline() {
-    var $ol = $('#timeline-ol').empty();
+    var $ol = $('#timeline-ol');
+    if ($ol.hasClass('ui-sortable')) $ol.sortable('destroy');   // rebuilt below, so drop the old instance
+    $ol.empty();
 
     if (events.length === 0) {
         $ol.append(
@@ -56,12 +60,36 @@ function renderTimeline() {
         $ol.append(insertSlot(i));
         $ol.append(eventCard(i));
     }
-    $ol.append(insertSlot(events.length));
+    $ol.append(insertSlot(events.length, true));   // prominent "Add event" after the last event
+    enableSort();
 }
 
-function insertSlot(index) {
-    return $('<li class="insert-slot"><button class="insert-btn" title="Insert event here">&#43;</button></li>')
-        .find('.insert-btn').attr('data-index', index).end();
+// index = where a click inserts; prominent = the big "Add event" slot after the last event
+function insertSlot(index, prominent) {
+    var $li = prominent
+        ? $('<li class="insert-slot add-after"><button class="insert-btn add-event-btn">&#43; Add event</button></li>')
+        : $('<li class="insert-slot"><button class="insert-btn" title="Insert event here">&#43;</button></li>');
+    return $li.find('.insert-btn').attr('data-index', index).end();
+}
+
+// drag an event card onto another to reorder; rebuild events[] from the new DOM order
+function enableSort() {
+    var $ol = $('#timeline-ol');
+    if (events.length < 2) return;
+    $ol.sortable({
+        items:     '> li.event',
+        distance:  8,               // small moves stay clicks (tap-to-edit), not drags
+        tolerance: 'pointer',
+        axis:      'x',
+        stop: function() {
+            var reordered = [];
+            $ol.children('li.event').each(function() {
+                reordered.push(events[parseInt($(this).attr('data-index'), 10)]);
+            });
+            events = reordered;
+            renderTimeline();
+        }
+    });
 }
 
 function eventCard(i) {
@@ -158,6 +186,7 @@ function openEventModal(index, isNew) {
     if (isNew) {
         editingIndex = null;
         insertIndex  = index;
+        eventImages  = [];
         $('#event-modal-title').text('Add Event');
         $('#ev-delete').attr('hidden', true);
         $('#ev-title, #ev-ntitle, #ev-date, #ev-ndate, #ev-desc, #ev-ndesc').val('');
@@ -165,6 +194,7 @@ function openEventModal(index, isNew) {
     } else {
         editingIndex = index;
         var e = events[index];
+        eventImages  = (e.images || []).slice();
         $('#event-modal-title').text('Edit Event');
         $('#ev-delete').removeAttr('hidden');
         $('#ev-title').val(e.title  || '');
@@ -175,8 +205,22 @@ function openEventModal(index, isNew) {
         $('#ev-ndesc').val(e.ndesc  || '');
         setNepali('ev-nepali', !!(e.ndn || e.ndate || e.ndesc));  // expand only if Nepali content exists
     }
+    renderEventImages();
     $('#event-modal').addClass('open');
     $('#ev-title').focus();
+}
+
+// draw the current event's image thumbnails (each with a remove button); hide "Add" once 2 are chosen
+function renderEventImages() {
+    var $list = $('#ev-images-list').empty();
+    eventImages.forEach(function(src, i) {
+        var $slot = $('<div class="ev-img-slot"></div>');
+        $('<img alt="event image">').attr('src', src).appendTo($slot);
+        $('<button type="button" class="ev-img-remove" title="Remove image">&times;</button>')
+            .attr('data-i', i).appendTo($slot);
+        $list.append($slot);
+    });
+    $('#ev-add-image').toggle(eventImages.length < 2);
 }
 
 function saveEventModal() {
@@ -184,12 +228,13 @@ function saveEventModal() {
     if (!title) { LOOMA.alert('Please enter an event title.', 5); return; }
 
     var e = {
-        title: title,
-        ndn:   $.trim($('#ev-ntitle').val()),
-        date:  $.trim($('#ev-date').val()),
-        ndate: $.trim($('#ev-ndate').val()),
-        desc:  $('#ev-desc').val(),
-        ndesc: $.trim($('#ev-ndesc').val())
+        title:  title,
+        ndn:    $.trim($('#ev-ntitle').val()),
+        date:   $.trim($('#ev-date').val()),
+        ndate:  $.trim($('#ev-ndate').val()),
+        desc:   $('#ev-desc').val(),
+        ndesc:  $.trim($('#ev-ndesc').val()),
+        images: eventImages.slice()
     };
 
     if (editingIndex !== null) events[editingIndex] = e;
@@ -203,6 +248,60 @@ function deleteEvent() {
     if (editingIndex !== null) events.splice(editingIndex, 1);
     $('#event-modal').removeClass('open');
     renderTimeline();
+}
+
+
+//////////////////////////////////
+///////   IMAGE SEARCH     ////////
+//////////////////////////////////
+// Reuses the shared Looma search panel (includes/looma-search.php + js/looma-search.js).
+// That code calls the globals displayResults() and clearResults() defined here, and
+// posts results into #results-div.
+
+var IMAGE_TYPES = { image:1, jpg:1, jpeg:1, png:1, gif:1 };
+
+function openImageSearch() {
+    if (eventImages.length >= 2) { LOOMA.alert('An event can have at most 2 images.', 5); return; }
+    $('#image-checkbox').prop('checked', true);   // constrain the shared search to pictures
+    $('#results-div').empty();
+    $('#imgsearch-modal').addClass('open');
+    $('#search-term').val('').focus();
+}
+
+// called by looma-search.js with the raw search response
+function displayResults(result) {
+    var $div = $('#results-div').empty();
+    var list = (result && result.list) ? result.list : [];
+    var pics = list.filter(function(it) { return IMAGE_TYPES[(it.ft || '').toLowerCase()]; });
+
+    if (!pics.length) { $div.html('<p class="imgsearch-empty">No images found.</p>'); return; }
+
+    pics.forEach(function(it) {
+        var fp    = it.fp || '';
+        var fn    = it.fn || it.nfn || '';
+        var full  = fp + fn;                                        // full-size image (see looma-play-image.php)
+        var thumb = LOOMA.thumbnail(fn, fp, it.ft, it.thumb) || full;
+        var dn    = it.dn || it.ndn || fn;
+
+        var $tile = $('<button type="button" class="imgresult"></button>')
+            .attr('data-src', full).attr('title', dn);
+        $('<img alt="">').attr('src', thumb)
+            .on('error', function() { $(this).off('error').attr('src', full); })  // fall back to full image
+            .appendTo($tile);
+        $('<span class="imgresult-dn"></span>').text(dn).appendTo($tile);
+        $div.append($tile);
+    });
+}
+
+// looma-search.js clears results through this hook
+function clearResults() { $('#results-div').empty(); }
+
+function addSelectedImage(src) {
+    if (!src) return;
+    if (eventImages.length >= 2) { LOOMA.alert('An event can have at most 2 images.', 5); return; }
+    eventImages.push(src);
+    renderEventImages();
+    $('#imgsearch-modal').removeClass('open');
 }
 
 
@@ -230,9 +329,10 @@ function signature() {
 function packEvents() {
     return events.map(function(e) {
         var ev = { title: e.title, date: e.date, popup: [e.desc || ''] };
-        if (e.ndn)   ev.ndn    = e.ndn;
-        if (e.ndate) ev.ndate  = e.ndate;
-        if (e.ndesc) ev.npopup = [e.ndesc];
+        if (e.ndn)                   ev.ndn    = e.ndn;
+        if (e.ndate)                 ev.ndate  = e.ndate;
+        if (e.ndesc)                 ev.npopup = [e.ndesc];
+        if (e.images && e.images.length) ev.images = e.images;
         return ev;
     });
 }
@@ -273,12 +373,13 @@ function editor_display(response) {
         var popup  = ev.popup  || [];
         var npopup = ev.npopup || [];
         return {
-            title: ev.title || '',
-            ndn:   ev.ndn   || '',
-            date:  ev.date  || '',
-            ndate: ev.ndate || '',
-            desc:  popup[0] || '',
-            ndesc: npopup[0] || ''
+            title:  ev.title || '',
+            ndn:    ev.ndn   || '',
+            date:   ev.date  || '',
+            ndate:  ev.ndate || '',
+            desc:   popup[0] || '',
+            ndesc:  npopup[0] || '',
+            images: Array.isArray(ev.images) ? ev.images : []
         };
     });
 
@@ -351,6 +452,16 @@ $(document).ready(function() {
     // --- event modal ---
     $('#ev-done').on('click', saveEventModal);
     $('#ev-delete').on('click', deleteEvent);
+
+    // --- event images ---
+    $('#ev-add-image').on('click', openImageSearch);
+    $('#ev-images-list').on('click', '.ev-img-remove', function() {
+        eventImages.splice(parseInt($(this).attr('data-i'), 10), 1);
+        renderEventImages();
+    });
+    $('#results-div').on('click', '.imgresult', function() {
+        addSelectedImage($(this).attr('data-src'));
+    });
 
     // close (X) buttons - just hide, no changes applied
     $('.modal-close').on('click', function() { $('#' + $(this).data('modal')).removeClass('open'); });

--- a/js/looma-edit-history.js
+++ b/js/looma-edit-history.js
@@ -117,7 +117,6 @@ function eventCard(i) {
 function openTimelineModal() {
     $('#tl-title').val(currentname || '');
     $('#tl-ntitle').val(timeline.ndn || '');
-    $('#tl-cover-url').val('');
     pendingThumb = timeline.thumb || '';
     showCoverPreview(pendingThumb);
     setNepali('tl-nepali', !!timeline.ndn);     // expand only if a Nepali title already exists
@@ -147,34 +146,12 @@ function saveTimelineModal() {
     var title = $.trim($('#tl-title').val());
     if (!title) { LOOMA.alert('Please enter a timeline title.', 5); return; }
 
-    var urlVal = $.trim($('#tl-cover-url').val());
-    if (urlVal) pendingThumb = urlVal;    // a pasted URL overrides
-
     currentname   = title;
     timeline.ndn  = $.trim($('#tl-ntitle').val());
     timeline.thumb = pendingThumb || '';
     setname(currentname, loginname);
 
     $('#timeline-modal').removeClass('open');
-}
-
-// read a chosen image file, downscale it to a small data-URL (no server upload needed)
-function loadImageToThumb(file, cb) {
-    var reader = new FileReader();
-    reader.onload = function(ev) {
-        var img = new Image();
-        img.onload = function() {
-            var max = 400, w = img.width, h = img.height;
-            if (w > h && w > max)      { h = Math.round(h * max / w); w = max; }
-            else if (h >= w && h > max){ w = Math.round(w * max / h); h = max; }
-            var c = document.createElement('canvas');
-            c.width = w; c.height = h;
-            c.getContext('2d').drawImage(img, 0, 0, w, h);
-            cb(c.toDataURL('image/jpeg', 0.8));
-        };
-        img.src = ev.target.result;
-    };
-    reader.readAsDataURL(file);
 }
 
 
@@ -260,8 +237,13 @@ function deleteEvent() {
 
 var IMAGE_TYPES = { image:1, jpg:1, jpeg:1, png:1, gif:1 };
 
-function openImageSearch() {
-    if (eventImages.length >= 2) { LOOMA.alert('An event can have at most 2 images.', 5); return; }
+var imgSearchTarget = 'event';   // 'event' or 'cover' - where a picked Library image goes
+
+function openImageSearch(target) {
+    imgSearchTarget = (target === 'cover') ? 'cover' : 'event';
+    if (imgSearchTarget === 'event' && eventImages.length >= 2) {
+        LOOMA.alert('An event can have at most 2 images.', 5); return;
+    }
     $('#image-checkbox').prop('checked', true);   // constrain the shared search to pictures
     $('#results-div').empty();
     $('#imgsearch-modal').addClass('open');
@@ -298,6 +280,12 @@ function clearResults() { $('#results-div').empty(); }
 
 function addSelectedImage(src) {
     if (!src) return;
+    if (imgSearchTarget === 'cover') {          // Timeline Details cover image
+        pendingThumb = src;
+        showCoverPreview(src);
+        $('#imgsearch-modal').removeClass('open');
+        return;
+    }
     if (eventImages.length >= 2) { LOOMA.alert('An event can have at most 2 images.', 5); return; }
     eventImages.push(src);
     renderEventImages();
@@ -337,17 +325,18 @@ function packEvents() {
     });
 }
 
-//  custom save: savefile() can't carry title/ndn/thumb, so post them directly
+//  custom save: savefile() can't carry title/ndn/thumb, so post them directly.
+//  returns the save promise (or undefined if the save was blocked) so callers can act after it.
 function editor_save(name) {
     if (events.length === 0) { LOOMA.alert('Add at least one event before saving.', 5); return; }
     if (!name) name = currentname;
 
-    $.post("looma-database-utilities.php", {
+    return $.post("looma-database-utilities.php", {
         cmd:        "save",
         collection: "histories",
         db:         currentDB,
         ft:         "history",
-        activity:   "false",          // NOT indexed as an activity (stays out of library search)
+        activity:   "true",           // index as an activity so it appears in the library search
         dn:         LOOMA.escapeHTML(name),
         title:      LOOMA.escapeHTML(name),
         ndn:        timeline.ndn || '',
@@ -388,8 +377,30 @@ function editor_display(response) {
 }
 
 function quit() {
-    if (callbacks['modified']()) savework(currentname, currentcollection, currentfiletype);
-    else window.history.back();
+    // no unsaved edits -> just leave, no prompt
+    if (!callbacks['modified']()) { window.history.back(); return; }
+
+    // one Save / Don't save / Cancel prompt. Reuses the file-commands save panel but calls
+    // editor_save directly, so there's no redundant second "confirm" dialog.
+    var $panel = $('#filesave-panel');
+    LOOMA.makeTransparent($('#main-container'));
+    $panel.find('#filesave-message').text('Save your changes before leaving?');
+    $panel.show();
+
+    function closePanel() {
+        $panel.hide();
+        LOOMA.makeOpaque($('#main-container'));
+        $panel.find('.dismiss').off('click');
+        $('#filesave-nosave, #filesave-save').off('click');
+    }
+    $panel.find('.dismiss').off('click').on('click', function() { closePanel(); });                    // Cancel -> stay
+    $('#filesave-nosave').off('click').on('click', function() { closePanel(); window.history.back(); }); // Don't save -> leave
+    $('#filesave-save').off('click').on('click', function() {                                           // Save -> save, then leave
+        closePanel();
+        var p = editor_save(currentname);
+        if (p && p.then) p.then(function() { window.history.back(); });
+        // if the save was blocked (e.g. empty timeline), stay so the user can fix it
+    });
 }
 
 
@@ -424,28 +435,10 @@ $(document).ready(function() {
 
     // --- timeline modal ---
     $('#timeline-details-btn').on('click', openTimelineModal);
-    $('#timeline-save-btn').on('click', function() {
-        savework(currentname, currentcollection, currentfiletype);
-    });
     $('#tl-done').on('click', saveTimelineModal);
-    $('#tl-choose-image').on('click', function() { $('#tl-cover-file').click(); });
-    $('#tl-cover-file').on('change', function() {
-        if (this.files && this.files[0]) {
-            loadImageToThumb(this.files[0], function(dataUrl) {
-                pendingThumb = dataUrl;
-                $('#tl-cover-url').val('');
-                showCoverPreview(dataUrl);
-            });
-        }
-    });
-    $('#tl-cover-url').on('input', function() {
-        var v = $.trim($(this).val());
-        if (v) { pendingThumb = v; showCoverPreview(v); }
-    });
+    $('#tl-choose-image').on('click', function() { openImageSearch('cover'); });
     $('#tl-remove-image').on('click', function() {
         pendingThumb = '';
-        $('#tl-cover-url').val('');
-        $('#tl-cover-file').val('');
         showCoverPreview('');
     });
 
@@ -454,7 +447,7 @@ $(document).ready(function() {
     $('#ev-delete').on('click', deleteEvent);
 
     // --- event images ---
-    $('#ev-add-image').on('click', openImageSearch);
+    $('#ev-add-image').on('click', function() { openImageSearch('event'); });
     $('#ev-images-list').on('click', '.ev-img-remove', function() {
         eventImages.splice(parseInt($(this).attr('data-i'), 10), 1);
         renderEventImages();

--- a/js/looma-history.js
+++ b/js/looma-history.js
@@ -118,7 +118,10 @@ $(document).ready (function() {
 
             var target = $(e.target);   //The element that has been clicked
             var header = $(target).html();
-            var descrip = $(target).attr("data-msg");   // The description of an event pulled from the json with looma-history.php
+            // prefer the manual Nepali popup text when the toggle is set to native; fall back to English
+            var histLang = LOOMA.readStore('language', 'cookie');
+            var ndescrip = $(target).attr("data-nmsg");
+            var descrip = (histLang === 'native' && ndescrip) ? ndescrip : $(target).attr("data-msg");   // event description from looma-history.php
 
             // Defining the popup function--creates a function, inserts a description, and maybe ids if there are any
             var historypopup = function(msg, msgtitle, notTransparent){

--- a/js/looma-history.js
+++ b/js/looma-history.js
@@ -141,6 +141,21 @@ $(document).ready (function() {
                         LOOMA.makeActivityButtonFromId($(target).attr("data-id2"), 'looma',"", $(".popup"));
                     }
 
+                    // inline images added in the History editor (up to 2)
+                    var imagesAttr = $(target).attr("data-images");
+                    if (imagesAttr) {
+                        try {
+                            var imgs = JSON.parse(imagesAttr);
+                            if (imgs && imgs.length) {
+                                var $wrap = $("<div class='popup-images'></div>");
+                                imgs.forEach(function(src) {
+                                    $("<img class='popup-image' draggable='false'>").attr('src', src).appendTo($wrap);
+                                });
+                                $wrap.appendTo($(".popup"));
+                            }
+                        } catch (err) { console.log('history popup images parse error', err); }
+                    }
+
                     $('#dismiss-popup').click(function() {
                         LOOMA.closePopup();
                     });

--- a/looma-database-utilities.php
+++ b/looma-database-utilities.php
@@ -483,7 +483,8 @@ require_once('includes/looma-utilities.php');
                 "author" => $_COOKIE['login'],
                 "date"   => gmdate("Y.m.d")  //using greenwich time
             );
-            if (isset($_REQUEST['thumb'])) $insert['thumb'] = $_REQUEST['thumb'];
+            if (isset($_REQUEST['ndn']))   $insert['ndn']   = $_REQUEST['ndn'];    // Nepali timeline title
+            if (isset($_REQUEST['thumb'])) $insert['thumb'] = $_REQUEST['thumb'];  // cover image (data-URL or path)
 
             // final param FALSE: do NOT create an 'activities' index entry, so these
             // timelines stay out of the general library/search - only the History editor lists them.

--- a/looma-database-utilities.php
+++ b/looma-database-utilities.php
@@ -466,6 +466,30 @@ require_once('includes/looma-utilities.php');
             $result = saveToMongo($dbCollection, trim(htmlspecialchars_decode($_REQUEST['dn'],ENT_QUOTES)), $_REQUEST['ft'], $insert, $activitycollection);
             echo json_encode($result);
         }
+        else if ($collection == "user_histories") {
+            // admin-created timelines. Saved ONLY to the 'user_histories' collection -
+            // the curated, read-only 'histories' collection is never referenced here.
+            // Stored in the native history shape (title + events) so the read-only
+            // viewer could render them, plus dn/ft so the File-menu Open/search works.
+            $save_dn = trim(htmlspecialchars_decode($_REQUEST['dn'],ENT_QUOTES));
+            $events  = isset($_REQUEST['data']) ? array_values($_REQUEST['data']) : array();
+
+            $insert = array(
+                "dn"     => $save_dn,       // used by File-menu Open/search + saveToMongo key
+                "ft"     => 'history',      // so File-menu search (type=history) finds it
+                "db"     => $_REQUEST['db'],
+                "title"  => $save_dn,       // native history-viewer field
+                "events" => $events,        // native history-viewer field
+                "author" => $_COOKIE['login'],
+                "date"   => gmdate("Y.m.d")  //using greenwich time
+            );
+            if (isset($_REQUEST['thumb'])) $insert['thumb'] = $_REQUEST['thumb'];
+
+            // final param FALSE: do NOT create an 'activities' index entry, so these
+            // timelines stay out of the general library/search - only the History editor lists them.
+            $result = saveToMongo($dbCollection, $save_dn, 'history', $insert, false);
+            echo json_encode($result);
+        }
         else if ($collection == "activities") {
             $insert = $_REQUEST['data'];
             $insert["date"] = gmdate("Y.m.d");  //using greenwich time

--- a/looma-database-utilities.php
+++ b/looma-database-utilities.php
@@ -466,9 +466,9 @@ require_once('includes/looma-utilities.php');
             $result = saveToMongo($dbCollection, trim(htmlspecialchars_decode($_REQUEST['dn'],ENT_QUOTES)), $_REQUEST['ft'], $insert, $activitycollection);
             echo json_encode($result);
         }
-        else if ($collection == "user_histories") {
-            // admin-created timelines. Saved ONLY to the 'user_histories' collection -
-            // the curated, read-only 'histories' collection is never referenced here.
+        else if ($collection == "histories") {
+            // admin-created timelines. Saved to the 'histories' collection alongside
+            // the curated timelines.
             // Stored in the native history shape (title + events) so the read-only
             // viewer could render them, plus dn/ft so the File-menu Open/search works.
             $save_dn = trim(htmlspecialchars_decode($_REQUEST['dn'],ENT_QUOTES));

--- a/looma-database-utilities.php
+++ b/looma-database-utilities.php
@@ -486,9 +486,10 @@ require_once('includes/looma-utilities.php');
             if (isset($_REQUEST['ndn']))   $insert['ndn']   = $_REQUEST['ndn'];    // Nepali timeline title
             if (isset($_REQUEST['thumb'])) $insert['thumb'] = $_REQUEST['thumb'];  // cover image (data-URL or path)
 
-            // final param FALSE: do NOT create an 'activities' index entry, so these
-            // timelines stay out of the general library/search - only the History editor lists them.
-            $result = saveToMongo($dbCollection, $save_dn, 'history', $insert, false);
+            // pass the request-driven $activitycollection so an 'ft:history' entry is
+            // added to the activities index (when saved with activity="true"), making
+            // these timelines discoverable in the general library/search like other content.
+            $result = saveToMongo($dbCollection, $save_dn, 'history', $insert, $activitycollection);
             echo json_encode($result);
         }
         else if ($collection == "activities") {

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -34,7 +34,7 @@ Revision: Looma 7.x
 ?>
 
     <link rel="Stylesheet" type="text/css" href="css/looma-filecommands.css">
-    <link rel="Stylesheet" type="text/css" href="css/looma-edit-history.css">
+    <link rel="Stylesheet" type="text/css" href="css/looma-edit-history.css?v=<?php echo @filemtime(__DIR__.'/css/looma-edit-history.css'); ?>">
 
 </head>
 
@@ -140,6 +140,6 @@ Revision: Looma 7.x
 
     <?php include ('includes/looma-filecommands.php'); ?>
 
-    <script src="js/looma-edit-history.js"></script>
+    <script src="js/looma-edit-history.js?v=<?php echo @filemtime(__DIR__.'/js/looma-edit-history.js'); ?>"></script>
 </body>
 </html>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -1,0 +1,94 @@
+<?php
+require_once('includes/looma-isloggedin.php');
+
+// NOTE: this code sending "header" must be before ANY data is sent to client-side
+$loggedin = loggedIn();
+$level = isset($_COOKIE['login-level']) ? $_COOKIE['login-level'] : null;
+if (!$loggedin) { header('Location: looma-login.php'); exit; }
+// admin-control only: lock down to admin / exec (matches Resource & Dictionary editors)
+if ($level !== 'admin' && $level !== 'exec') { header('Location: looma-home.php'); exit; }
+error_log("Starting History Timeline Edit session. logged in as: " . $loggedin);
+?>
+
+<!doctype html>
+<!--
+Filename: looma-edit-history.php
+Description: editor for user-created history timelines. Modeled on looma-edit-slideshow.php.
+             Reads/writes ONLY the 'user_histories' collection; the curated, read-only
+             'histories' collection (the 11 approved timelines) is never touched.
+
+Owner: VillageTech Solutions (villagetechsolutions.org)
+Revision: Looma 7.x
+ -->
+
+<?php   $page_title = 'Looma History Timeline Editor';
+        include ('includes/header.php');
+?>
+
+    <link rel = "Stylesheet" type = "text/css" href = "css/looma-search.css">
+    <link rel = "Stylesheet" type = "text/css" href = "css/looma-filecommands.css">
+    <link rel = "Stylesheet" type = "text/css" href = "css/looma-edit-history.css">
+
+</head>
+
+<body>
+
+    <div id="main-container">
+
+        <div id="header" class="inner-div">
+            <div id="title">Editing: <span class="filename">&lt;none&gt;</span> </div>
+            <img src="images/logos/LoomaLogoTransparent.png"  height="100%"/>
+            <span>Looma History Timeline Editor</span>
+        </div>
+
+        <div id="search-bar" class="inner-div">
+            <?php require_once ('includes/looma-search.php');?>
+            <button id="add-event">+ Add Event</button>
+        </div>
+
+
+        <div id="outerResultsDiv">
+            <div id="innerResultsMenu"></div>
+            <div id="results-div"></div>
+            <div id="innerResultsDiv">
+                <span class="hint">Search Results</span>
+            </div>
+        </div>
+        <div id="previewpanel" class="inner-div">
+            <div id = "preview"></div>
+            <span class="hint">Activity Preview</span><br><br><br>
+            <div id="hints">
+                <br>
+                <p class="hint">Use <b>File &rarr; New</b> to start a timeline, or <b>File &rarr; Open</b> to edit one of your own.</p>
+                <p class="hint">Click <b>+ Add Event</b> to add events to the timeline below.</p>
+                <p class="hint">To attach an activity to an event: click the event, search above, then click <b>Add</b>.</p>
+            </div>
+        </div>
+
+        <div id = "timeline">
+            <div id="timelineDisplay" class="timelineCenter">
+            </div>
+        </div>
+
+            <button type="button" id="timelineLeft" class="timelineScroll"></button>
+            <button type="button" id="timelineRight" class="timelineScroll"></button>
+
+    </div>
+
+    <?php   include('includes/looma-control-buttons.php');?>
+    <button class='control-button' id='dismiss' ></button>
+
+    <?php include ('includes/js-includes.php'); ?>
+
+    <script src="js/jquery-ui.min.js"></script>
+    <script src="js/jquery.hotkeys.js"></script>
+    <script src="js/tether.min.js"></script>
+    <script src="js/bootstrap.min.js"></script>
+
+    <?php include ('includes/looma-filecommands.php');?>
+
+    <script src="js/looma-media-controls.js"></script>
+    <script src="js/looma-search.js"></script>
+    <script src="js/looma-edit-history.js"></script>
+</body>
+</html>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -13,14 +13,17 @@ error_log("Starting History Timeline Edit session. logged in as: " . $loggedin);
 <!doctype html>
 <!--
 Filename: looma-edit-history.php
-Description: editor for user-created history timelines. The editing surface mirrors the
-             read-only history viewer (looma-history.php): a horizontal timeline with events
-             alternating above/below a line. Events are edited in place - tap the title or
-             date to type; use the pencil to edit description / Nepali text / linked activities.
+Description: editor for user-created history timelines.
 
-             Reads/writes ONLY the 'user_histories' collection; the curated, read-only
-             'histories' collection (the 11 approved timelines) is never touched.
-             The File-menu flow, save/load, and activity search reuse the Slideshow-editor patterns.
+    Flow: on entry you set the timeline's title (+ Nepali) and a cover image (Timeline modal).
+    Then you land on a blank timeline (the real looma-history.php format). Tap a "+" insert
+    slot to add an event, or tap an existing event to edit it (Event modal: title, date,
+    description, + optional Nepali). The description is what shows when an event is tapped in
+    the viewer.
+
+    Reads/writes ONLY the 'user_histories' collection; the curated, read-only 'histories'
+    collection (the 11 approved timelines) is never touched. File-menu / save / load reuse
+    the Slideshow-editor patterns.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -30,7 +33,6 @@ Revision: Looma 7.x
         include ('includes/header.php');
 ?>
 
-    <link rel="Stylesheet" type="text/css" href="css/looma-search.css">
     <link rel="Stylesheet" type="text/css" href="css/looma-filecommands.css">
     <link rel="Stylesheet" type="text/css" href="css/looma-edit-history.css">
 
@@ -47,10 +49,10 @@ Revision: Looma 7.x
         </div>
 
         <div id="toolbar-row">
-            <button id="add-event">&#43; Add Event</button>
+            <button id="timeline-details-btn">&#9998; Timeline Details</button>
             <button id="timelineLeft"  class="timelineScroll" title="Scroll left">&#8249;</button>
             <button id="timelineRight" class="timelineScroll" title="Scroll right">&#8250;</button>
-            <span class="edit-hint">Tap a title or date to edit it &bull; use the &#9998; on an event for description, Nepali text &amp; linked activities</span>
+            <span class="edit-hint">Tap a <b>&#43;</b> to add an event &bull; tap an event to edit it</span>
         </div>
 
         <!-- the editable timeline (mirrors looma-history.php's #playground / .timeline) -->
@@ -58,47 +60,63 @@ Revision: Looma 7.x
             <section class="timeline">
                 <ol id="timeline-ol"></ol>
             </section>
-            <div id="empty-hint">
-                This timeline is empty.<br>
-                Click <b>&#43; Add Event</b> to begin, or use <b>File &rarr; Open</b> to edit one of your own timelines.
-            </div>
         </div>
 
     </div>
 
-    <!-- per-event details editor (Nepali title/date, description EN/NP, linked activities) -->
-    <div id="event-details" class="overlay" hidden>
-        <div class="details-card">
-            <button id="details-close" title="Done">&times;</button>
-            <h2>Edit Event Details</h2>
+    <!-- ===== Modal A: Timeline details (title + Nepali + cover image) ===== -->
+    <div id="timeline-modal" class="modal" hidden>
+        <div class="modal-card">
+            <button class="modal-close" data-modal="timeline-modal" title="Close">&times;</button>
+            <h2>Timeline Details</h2>
 
-            <label>Title (English)</label>
-            <input id="d-title" type="text" placeholder="Event title (English)">
+            <label>Timeline title (English)</label>
+            <input id="tl-title" type="text" placeholder="e.g. History of Nepal">
+
             <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; (Nepali title &ndash; optional)</label>
-            <input id="d-ntitle" type="text" placeholder="Nepali title">
+            <input id="tl-ntitle" type="text" placeholder="Nepali title">
 
-            <label>Date (English)</label>
-            <input id="d-date" type="text" placeholder="e.g. 1543">
-            <label>&#2350;&#2367;&#2340;&#2367; (Nepali date &ndash; optional)</label>
-            <input id="d-ndate" type="text" placeholder="Nepali date">
-
-            <label>Description (English)</label>
-            <textarea id="d-desc" placeholder="Shown in the popup when the event is tapped"></textarea>
-            <label>&#2357;&#2367;&#2357;&#2352;&#2339; (Nepali description &ndash; optional)</label>
-            <textarea id="d-ndesc" placeholder="Nepali description"></textarea>
-
-            <label>Linked activities (up to 2)</label>
-            <div id="d-activities"></div>
-            <button id="d-link-activity" type="button">&#43; Link an activity&hellip;</button>
-
-            <!-- activity search (reveals when linking); reuses looma-search.php + looma-search.js -->
-            <div id="activity-search" hidden>
-                <?php require_once ('includes/looma-search.php'); ?>
-                <div id="activity-results"></div>
+            <label>Cover image (optional)</label>
+            <div id="tl-cover-row">
+                <img id="tl-cover-preview" alt="cover preview" hidden>
+                <div id="tl-cover-actions">
+                    <button id="tl-choose-image" type="button">Choose image&hellip;</button>
+                    <button id="tl-remove-image" type="button" hidden>Remove</button>
+                    <input id="tl-cover-file" type="file" accept="image/*" hidden>
+                    <input id="tl-cover-url" type="text" placeholder="&hellip;or paste an image URL / path">
+                </div>
             </div>
 
-            <div class="details-actions">
-                <button id="details-done">Done</button>
+            <div class="modal-actions">
+                <button id="tl-done" class="primary">Done</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- ===== Modal B: Event (title, date, description, + Nepali) ===== -->
+    <div id="event-modal" class="modal" hidden>
+        <div class="modal-card">
+            <button class="modal-close" data-modal="event-modal" title="Close">&times;</button>
+            <h2 id="event-modal-title">Add Event</h2>
+
+            <label>Event title (English)</label>
+            <input id="ev-title" type="text" placeholder="e.g. Unification of Nepal">
+            <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; (Nepali title &ndash; optional)</label>
+            <input id="ev-ntitle" type="text" placeholder="Nepali title">
+
+            <label>Date (English)</label>
+            <input id="ev-date" type="text" placeholder="e.g. 1768">
+            <label>&#2350;&#2367;&#2340;&#2367; (Nepali date &ndash; optional)</label>
+            <input id="ev-ndate" type="text" placeholder="Nepali date">
+
+            <label>Description (shown when the event is tapped)</label>
+            <textarea id="ev-desc" placeholder="Description (English)"></textarea>
+            <label>&#2357;&#2367;&#2357;&#2352;&#2339; (Nepali description &ndash; optional)</label>
+            <textarea id="ev-ndesc" placeholder="Nepali description"></textarea>
+
+            <div class="modal-actions">
+                <button id="ev-delete" hidden>Delete event</button>
+                <button id="ev-done" class="primary">Done</button>
             </div>
         </div>
     </div>
@@ -115,8 +133,6 @@ Revision: Looma 7.x
 
     <?php include ('includes/looma-filecommands.php'); ?>
 
-    <script src="js/looma-media-controls.js"></script>
-    <script src="js/looma-search.js"></script>
     <script src="js/looma-edit-history.js"></script>
 </body>
 </html>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -21,9 +21,8 @@ Description: editor for user-created history timelines.
     description, + optional Nepali). The description is what shows when an event is tapped in
     the viewer.
 
-    Reads/writes ONLY the 'user_histories' collection; the curated, read-only 'histories'
-    collection (the 11 approved timelines) is never touched. File-menu / save / load reuse
-    the Slideshow-editor patterns.
+    Reads/writes the 'histories' collection, alongside the curated approved timelines.
+    File-menu / save / load reuse the Slideshow-editor patterns.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -50,6 +49,7 @@ Revision: Looma 7.x
 
         <div id="toolbar-row">
             <button id="timeline-details-btn">&#9998; Timeline Details</button>
+            <button id="timeline-save-btn">Save</button>
             <button id="timelineLeft"  class="timelineScroll" title="Scroll left">&#8249;</button>
             <button id="timelineRight" class="timelineScroll" title="Scroll right">&#8250;</button>
             <span class="edit-hint">Tap a <b>&#43;</b> to add an event &bull; tap an event to edit it</span>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -13,9 +13,14 @@ error_log("Starting History Timeline Edit session. logged in as: " . $loggedin);
 <!doctype html>
 <!--
 Filename: looma-edit-history.php
-Description: editor for user-created history timelines. Modeled on looma-edit-slideshow.php.
+Description: editor for user-created history timelines. The editing surface mirrors the
+             read-only history viewer (looma-history.php): a horizontal timeline with events
+             alternating above/below a line. Events are edited in place - tap the title or
+             date to type; use the pencil to edit description / Nepali text / linked activities.
+
              Reads/writes ONLY the 'user_histories' collection; the curated, read-only
              'histories' collection (the 11 approved timelines) is never touched.
+             The File-menu flow, save/load, and activity search reuse the Slideshow-editor patterns.
 
 Owner: VillageTech Solutions (villagetechsolutions.org)
 Revision: Looma 7.x
@@ -25,9 +30,9 @@ Revision: Looma 7.x
         include ('includes/header.php');
 ?>
 
-    <link rel = "Stylesheet" type = "text/css" href = "css/looma-search.css">
-    <link rel = "Stylesheet" type = "text/css" href = "css/looma-filecommands.css">
-    <link rel = "Stylesheet" type = "text/css" href = "css/looma-edit-history.css">
+    <link rel="Stylesheet" type="text/css" href="css/looma-search.css">
+    <link rel="Stylesheet" type="text/css" href="css/looma-filecommands.css">
+    <link rel="Stylesheet" type="text/css" href="css/looma-edit-history.css">
 
 </head>
 
@@ -35,48 +40,71 @@ Revision: Looma 7.x
 
     <div id="main-container">
 
-        <div id="header" class="inner-div">
-            <div id="title">Editing: <span class="filename">&lt;none&gt;</span> </div>
-            <img src="images/logos/LoomaLogoTransparent.png"  height="100%"/>
-            <span>Looma History Timeline Editor</span>
+        <div id="header">
+            <div id="title">Editing: <span class="filename">&lt;none&gt;</span></div>
+            <img src="images/logos/LoomaLogoTransparent.png" height="100%"/>
+            <span id="editor-name">Looma History Timeline Editor</span>
         </div>
 
-        <div id="search-bar" class="inner-div">
-            <?php require_once ('includes/looma-search.php');?>
-            <button id="add-event">+ Add Event</button>
+        <div id="toolbar-row">
+            <button id="add-event">&#43; Add Event</button>
+            <button id="timelineLeft"  class="timelineScroll" title="Scroll left">&#8249;</button>
+            <button id="timelineRight" class="timelineScroll" title="Scroll right">&#8250;</button>
+            <span class="edit-hint">Tap a title or date to edit it &bull; use the &#9998; on an event for description, Nepali text &amp; linked activities</span>
         </div>
 
-
-        <div id="outerResultsDiv">
-            <div id="innerResultsMenu"></div>
-            <div id="results-div"></div>
-            <div id="innerResultsDiv">
-                <span class="hint">Search Results</span>
+        <!-- the editable timeline (mirrors looma-history.php's #playground / .timeline) -->
+        <div id="playground">
+            <section class="timeline">
+                <ol id="timeline-ol"></ol>
+            </section>
+            <div id="empty-hint">
+                This timeline is empty.<br>
+                Click <b>&#43; Add Event</b> to begin, or use <b>File &rarr; Open</b> to edit one of your own timelines.
             </div>
         </div>
-        <div id="previewpanel" class="inner-div">
-            <div id = "preview"></div>
-            <span class="hint">Activity Preview</span><br><br><br>
-            <div id="hints">
-                <br>
-                <p class="hint">Use <b>File &rarr; New</b> to start a timeline, or <b>File &rarr; Open</b> to edit one of your own.</p>
-                <p class="hint">Click <b>+ Add Event</b> to add events to the timeline below.</p>
-                <p class="hint">To attach an activity to an event: click the event, search above, then click <b>Add</b>.</p>
-            </div>
-        </div>
-
-        <div id = "timeline">
-            <div id="timelineDisplay" class="timelineCenter">
-            </div>
-        </div>
-
-            <button type="button" id="timelineLeft" class="timelineScroll"></button>
-            <button type="button" id="timelineRight" class="timelineScroll"></button>
 
     </div>
 
-    <?php   include('includes/looma-control-buttons.php');?>
-    <button class='control-button' id='dismiss' ></button>
+    <!-- per-event details editor (Nepali title/date, description EN/NP, linked activities) -->
+    <div id="event-details" class="overlay" hidden>
+        <div class="details-card">
+            <button id="details-close" title="Done">&times;</button>
+            <h2>Edit Event Details</h2>
+
+            <label>Title (English)</label>
+            <input id="d-title" type="text" placeholder="Event title (English)">
+            <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; (Nepali title &ndash; optional)</label>
+            <input id="d-ntitle" type="text" placeholder="Nepali title">
+
+            <label>Date (English)</label>
+            <input id="d-date" type="text" placeholder="e.g. 1543">
+            <label>&#2350;&#2367;&#2340;&#2367; (Nepali date &ndash; optional)</label>
+            <input id="d-ndate" type="text" placeholder="Nepali date">
+
+            <label>Description (English)</label>
+            <textarea id="d-desc" placeholder="Shown in the popup when the event is tapped"></textarea>
+            <label>&#2357;&#2367;&#2357;&#2352;&#2339; (Nepali description &ndash; optional)</label>
+            <textarea id="d-ndesc" placeholder="Nepali description"></textarea>
+
+            <label>Linked activities (up to 2)</label>
+            <div id="d-activities"></div>
+            <button id="d-link-activity" type="button">&#43; Link an activity&hellip;</button>
+
+            <!-- activity search (reveals when linking); reuses looma-search.php + looma-search.js -->
+            <div id="activity-search" hidden>
+                <?php require_once ('includes/looma-search.php'); ?>
+                <div id="activity-results"></div>
+            </div>
+
+            <div class="details-actions">
+                <button id="details-done">Done</button>
+            </div>
+        </div>
+    </div>
+
+    <?php include('includes/looma-control-buttons.php'); ?>
+    <button class='control-button' id='dismiss'></button>
 
     <?php include ('includes/js-includes.php'); ?>
 
@@ -85,7 +113,7 @@ Revision: Looma 7.x
     <script src="js/tether.min.js"></script>
     <script src="js/bootstrap.min.js"></script>
 
-    <?php include ('includes/looma-filecommands.php');?>
+    <?php include ('includes/looma-filecommands.php'); ?>
 
     <script src="js/looma-media-controls.js"></script>
     <script src="js/looma-search.js"></script>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -64,17 +64,14 @@ Revision: Looma 7.x
 
     </div>
 
-    <!-- ===== Modal A: Timeline details (title + Nepali + cover image) ===== -->
-    <div id="timeline-modal" class="modal" hidden>
+    <!-- ===== Modal A: Timeline details (title + cover image; Nepali behind a toggle) ===== -->
+    <div id="timeline-modal" class="modal">
         <div class="modal-card">
             <button class="modal-close" data-modal="timeline-modal" title="Close">&times;</button>
             <h2>Timeline Details</h2>
 
-            <label>Timeline title (English)</label>
+            <label>Timeline title</label>
             <input id="tl-title" type="text" placeholder="e.g. History of Nepal">
-
-            <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; (Nepali title &ndash; optional)</label>
-            <input id="tl-ntitle" type="text" placeholder="Nepali title">
 
             <label>Cover image (optional)</label>
             <div id="tl-cover-row">
@@ -87,32 +84,42 @@ Revision: Looma 7.x
                 </div>
             </div>
 
+            <button type="button" class="nepali-toggle" data-target="tl-nepali">&#43; Add Nepali translation</button>
+            <div id="tl-nepali" class="nepali-fields">
+                <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; &mdash; Nepali title</label>
+                <input id="tl-ntitle" type="text" placeholder="Nepali title">
+            </div>
+
             <div class="modal-actions">
                 <button id="tl-done" class="primary">Done</button>
             </div>
         </div>
     </div>
 
-    <!-- ===== Modal B: Event (title, date, description, + Nepali) ===== -->
-    <div id="event-modal" class="modal" hidden>
+    <!-- ===== Modal B: Event (title, date, description; Nepali behind a toggle) ===== -->
+    <div id="event-modal" class="modal">
         <div class="modal-card">
             <button class="modal-close" data-modal="event-modal" title="Close">&times;</button>
             <h2 id="event-modal-title">Add Event</h2>
 
-            <label>Event title (English)</label>
+            <label>Event title</label>
             <input id="ev-title" type="text" placeholder="e.g. Unification of Nepal">
-            <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; (Nepali title &ndash; optional)</label>
-            <input id="ev-ntitle" type="text" placeholder="Nepali title">
 
-            <label>Date (English)</label>
+            <label>Date</label>
             <input id="ev-date" type="text" placeholder="e.g. 1768">
-            <label>&#2350;&#2367;&#2340;&#2367; (Nepali date &ndash; optional)</label>
-            <input id="ev-ndate" type="text" placeholder="Nepali date">
 
             <label>Description (shown when the event is tapped)</label>
-            <textarea id="ev-desc" placeholder="Description (English)"></textarea>
-            <label>&#2357;&#2367;&#2357;&#2352;&#2339; (Nepali description &ndash; optional)</label>
-            <textarea id="ev-ndesc" placeholder="Nepali description"></textarea>
+            <textarea id="ev-desc" placeholder="Description"></textarea>
+
+            <button type="button" class="nepali-toggle" data-target="ev-nepali">&#43; Add Nepali translation</button>
+            <div id="ev-nepali" class="nepali-fields">
+                <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; &mdash; Nepali title</label>
+                <input id="ev-ntitle" type="text" placeholder="Nepali title">
+                <label>&#2350;&#2367;&#2340;&#2367; &mdash; Nepali date</label>
+                <input id="ev-ndate" type="text" placeholder="Nepali date">
+                <label>&#2357;&#2367;&#2357;&#2352;&#2339; &mdash; Nepali description</label>
+                <textarea id="ev-ndesc" placeholder="Nepali description"></textarea>
+            </div>
 
             <div class="modal-actions">
                 <button id="ev-delete" hidden>Delete event</button>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -78,7 +78,7 @@ Revision: Looma 7.x
                 <img id="tl-cover-preview" alt="cover preview" hidden>
                 <div id="tl-cover-actions">
                     <button id="tl-choose-image" type="button">Choose image&hellip;</button>
-                    <button id="tl-remove-image" type="button" hidden>Remove</button>
+                    <button id="tl-remove-image" type="button" hidden>Remove image</button>
                     <input id="tl-cover-file" type="file" accept="image/*" hidden>
                     <input id="tl-cover-url" type="text" placeholder="&hellip;or paste an image URL / path">
                 </div>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -52,7 +52,7 @@ Revision: Looma 7.x
             <button id="timeline-save-btn">Save</button>
             <button id="timelineLeft"  class="timelineScroll" title="Scroll left">&#8249;</button>
             <button id="timelineRight" class="timelineScroll" title="Scroll right">&#8250;</button>
-            <span class="edit-hint">Tap a <b>&#43;</b> to add an event &bull; tap an event to edit it</span>
+            <span class="edit-hint"><b>&#43; Add event</b> adds after the last event &bull; drag an event to reorder &bull; tap an event to edit it</span>
         </div>
 
         <!-- the editable timeline (mirrors looma-history.php's #playground / .timeline) -->
@@ -111,6 +111,12 @@ Revision: Looma 7.x
             <label>Description (shown when the event is tapped)</label>
             <textarea id="ev-desc" placeholder="Description"></textarea>
 
+            <label>Images (up to 2, shown in the event's popup)</label>
+            <div id="ev-images">
+                <div id="ev-images-list"></div>
+                <button type="button" id="ev-add-image">&#43; Add image from Library</button>
+            </div>
+
             <button type="button" class="nepali-toggle" data-target="ev-nepali">&#43; Add Nepali translation</button>
             <div id="ev-nepali" class="nepali-fields">
                 <label>&#2358;&#2368;&#2352;&#2381;&#2359;&#2325; &mdash; Nepali title</label>
@@ -128,6 +134,16 @@ Revision: Looma 7.x
         </div>
     </div>
 
+    <!-- ===== Image search overlay: pick up to 2 images from the Looma Library ===== -->
+    <div id="imgsearch-modal" class="modal">
+        <div class="modal-card imgsearch-card">
+            <button class="modal-close" data-modal="imgsearch-modal" title="Close">&times;</button>
+            <h2>Add an image from the Looma Library</h2>
+            <?php include ('includes/looma-search.php'); ?>
+            <div id="results-div"></div>
+        </div>
+    </div>
+
     <?php include('includes/looma-control-buttons.php'); ?>
     <button class='control-button' id='dismiss'></button>
 
@@ -140,6 +156,7 @@ Revision: Looma 7.x
 
     <?php include ('includes/looma-filecommands.php'); ?>
 
+    <script src="js/looma-search.js"></script>
     <script src="js/looma-edit-history.js?v=<?php echo @filemtime(__DIR__.'/js/looma-edit-history.js'); ?>"></script>
 </body>
 </html>

--- a/looma-edit-history.php
+++ b/looma-edit-history.php
@@ -49,7 +49,6 @@ Revision: Looma 7.x
 
         <div id="toolbar-row">
             <button id="timeline-details-btn">&#9998; Timeline Details</button>
-            <button id="timeline-save-btn">Save</button>
             <button id="timelineLeft"  class="timelineScroll" title="Scroll left">&#8249;</button>
             <button id="timelineRight" class="timelineScroll" title="Scroll right">&#8250;</button>
             <span class="edit-hint"><b>&#43; Add event</b> adds after the last event &bull; drag an event to reorder &bull; tap an event to edit it</span>
@@ -77,10 +76,8 @@ Revision: Looma 7.x
             <div id="tl-cover-row">
                 <img id="tl-cover-preview" alt="cover preview" hidden>
                 <div id="tl-cover-actions">
-                    <button id="tl-choose-image" type="button">Choose image&hellip;</button>
+                    <button id="tl-choose-image" type="button">Choose image from Library&hellip;</button>
                     <button id="tl-remove-image" type="button" hidden>Remove image</button>
-                    <input id="tl-cover-file" type="file" accept="image/*" hidden>
-                    <input id="tl-cover-url" type="text" placeholder="&hellip;or paste an image URL / path">
                 </div>
             </div>
 

--- a/looma-histories.php
+++ b/looma-histories.php
@@ -31,7 +31,11 @@ logPageHit('histories');
 
         echo "<table><tr>";
 
-        $histories = mongoFind($histories_collection, [], null, null, null);
+        // curated timelines (looma DB) + admin-created ones (loomalocal DB), so
+        // timelines made in the editor appear here next to the curated ones
+        $histories = iterator_to_array(mongoFind($histories_collection, [], null, null, null), false);
+        $histories = array_merge($histories,
+            iterator_to_array(mongoFind($local_histories_collection, [], null, null, null), false));
 
         foreach ($histories as $history) {
 
@@ -39,7 +43,7 @@ logPageHit('histories');
             $dn = $history['title'];
             $ndn = isset($history['ndn']) ?  $history['ndn'] : "";
             $ft = "history";
-            $thumb = $history['thumb'];
+            $thumb = isset($history['thumb']) ? $history['thumb'] : "";
             $id = $history['_id'];  //mongoID of the descriptor for this lesson
             makeActivityButton($ft, "", "", $dn, $ndn, $thumb, "", $id, "", "", "", "", "", "", null, null,null,null);
             echo "</td>";

--- a/looma-history.php
+++ b/looma-history.php
@@ -8,6 +8,18 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
   <?php $page_title = 'Looma History Timeline';
 
     include ("includes/header.php");
+
+    // Returns bilingual span markup for the language toggle. CSS + LOOMA.translate()
+    // show either the .english or .native span based on the 'language' cookie.
+    // Falls back to the English string when the manual Nepali translation is empty,
+    // so the Nepali view never renders blank. Does NOT machine-translate anything.
+    if (!function_exists('bilingualHist')) {
+        function bilingualHist($en, $np) {
+            $en = (string) $en;
+            $np = ($np === null || $np === '') ? $en : (string) $np;
+            return "<span class='english'>" . $en . "</span><span class='native'>" . $np . "</span>";
+        }
+    }
   ?>
 
     <link href='css/looma-history.css' rel='stylesheet' type='text/css'>
@@ -63,7 +75,7 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
         <button class="returnToLeftmost">   <img src="images/reverse-double-arrow.png">   </button>
 
         <?php
-            echo "<h1>"; bilingual($title,$ndn); echo "</h1>";
+            echo "<h1>" . bilingualHist($title, $ndn) . "</h1>";
             echo '<div id="playground">';
             echo '<section class ="timeline">';
             echo '<ol>';
@@ -74,8 +86,12 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
                   $id1 = "";
                   $id2 = "";
 
-                   if(isset($event['popup'][0]))
+                   if(isset($event['popup'][0])) {
                         $msg = 'data-msg=' .  $event['popup'][0] ;
+                        // manual Nepali popup text; JS falls back to data-msg when absent
+                        if(isset($event['npopup'][0]) && $event['npopup'][0] !== '')
+                             $msg .= ' data-nmsg=' . $event['npopup'][0];
+                   }
 
                   if(isset($event['popup'][1]))
                         $id1 = 'data-id1=' . $event['popup'][1];
@@ -93,9 +109,9 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
 
                        <div class="dropdown" style="float:">'; // edited out
 
-                   echo '<button class="dropbtn"' .  " " . $id1 . " " . $id2 . " " . $msg . '>' .  $event['title'] . '</button>';
+                   echo '<button class="dropbtn"' .  " " . $id1 . " " . $id2 . " " . $msg . '>' .  bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
 
-                   echo '<button class="dropdate">' . $event['date'] . '</button>'; //dropbtn before dropdate so dropbtn is on top
+                   echo '<button class="dropdate">' . bilingualHist($event['date'], isset($event['ndate']) ? $event['ndate'] : '') . '</button>'; //dropbtn before dropdate so dropbtn is on top
 
                        '</div>
 
@@ -110,8 +126,8 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
 
                        <div class="dropdown" style="float:">'; // edited out
 
-                       echo '<button class="dropdate">' . $event['date'] . '</button>';
-                       echo '<button class="dropbtn"' . " " . $id1 . " " . $id2 . " " . $msg . '>' . $event['title'] . '</button>';
+                       echo '<button class="dropdate">' . bilingualHist($event['date'], isset($event['ndate']) ? $event['ndate'] : '') . '</button>';
+                       echo '<button class="dropbtn"' . " " . $id1 . " " . $id2 . " " . $msg . '>' . bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
 
                        '</div>
                    </li>';

--- a/looma-history.php
+++ b/looma-history.php
@@ -99,6 +99,11 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
                   if(isset($event['popup'][2]))
                         $id2 = 'data-id2='. $event['popup'][2];
 
+                  // up to 2 Library images shown inline in the popup (looma-edit-history.js)
+                  $imgs = "";
+                  if(isset($event['images']) && is_array($event['images']) && count($event['images']))
+                        $imgs = 'data-images="' . htmlspecialchars(json_encode(array_values($event['images'])), ENT_QUOTES) . '"';
+
                   if ($count%2 == 0)
                   {
                    echo '
@@ -109,7 +114,7 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
 
                        <div class="dropdown" style="float:">'; // edited out
 
-                   echo '<button class="dropbtn"' .  " " . $id1 . " " . $id2 . " " . $msg . '>' .  bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
+                   echo '<button class="dropbtn" ' . $imgs .  " " . $id1 . " " . $id2 . " " . $msg . '>' .  bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
 
                    echo '<button class="dropdate">' . bilingualHist($event['date'], isset($event['ndate']) ? $event['ndate'] : '') . '</button>'; //dropbtn before dropdate so dropbtn is on top
 
@@ -127,7 +132,7 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
                        <div class="dropdown" style="float:">'; // edited out
 
                        echo '<button class="dropdate">' . bilingualHist($event['date'], isset($event['ndate']) ? $event['ndate'] : '') . '</button>';
-                       echo '<button class="dropbtn"' . " " . $id1 . " " . $id2 . " " . $msg . '>' . bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
+                       echo '<button class="dropbtn" ' . $imgs . " " . $id1 . " " . $id2 . " " . $msg . '>' . bilingualHist($event['title'], isset($event['ndn']) ? $event['ndn'] : '') . '</button>';
 
                        '</div>
                    </li>';

--- a/looma-history.php
+++ b/looma-history.php
@@ -54,9 +54,12 @@ Description: Creates history timelines with search, scroll, lookup, speech, and 
         else $query = array('_id' => mongoID($_REQUEST['id']));
 
         //$cursor =  $history_collection->find($query, array("title"=>1, "events"=>1)); //should be findOne()  ??
-        $cursor =  mongoFind($history_collection, $query, null, null, null); //should be findOne()  ??
+        // check the curated (looma) DB first, then fall back to admin-created timelines (loomalocal)
+        $docs = iterator_to_array(mongoFind($history_collection, $query, null, null, null), false);
+        if (count($docs) === 0)
+            $docs = iterator_to_array(mongoFind($local_histories_collection, $query, null, null, null), false);
 
-        foreach ($cursor as $doc) {
+        foreach ($docs as $doc) {
 
             $title = isset($doc['title']) ? $doc['title'] : null;
             $ndn = isset($doc['ndn']) ? $doc['ndn'] : $title;

--- a/looma-settings.php
+++ b/looma-settings.php
@@ -64,6 +64,10 @@ Description:  for Looma 2
                  <button id="requestcontent" class="admin-control" >Dictionary Editor</button>
              </a>
 
+             <a href="looma-edit-history.php">
+                 <button class="admin-control" >History Timeline Editor</button>
+             </a>
+
              <a href="looma-text-scan.php">
                  <button id="textscan" class="admin-control" >Scan Text Files</button>
              </a>


### PR DESCRIPTION
## History Timeline Editor

This branch adds and refines the admin/exec History Timeline Editor (`looma-edit-history.php`) for creating user-authored history timelines in the `histories` collection, plus the most recent round of improvements below.

### Latest changes
- Clearer "Add event" UI — a prominent green ＋ Add event button at the end of the timeline appends after the last event; the inline "+" slots are de-emphasized for precise inserts. This fixes events being added in the wrong spot.
- Up to 2 images per event popup: images are chosen from the Looma Library via the shared image-search panel (`includes/looma-search.php` / `js/looma-search.js`) and are stored in a dedicated `images` field on each event. They render inline in the read-only viewer's popup (`looma-history.php` / `js/looma-history.js`).
- Drag-and-drop reordering of events (jQuery UI sortable; rebuilds `events[]` from DOM order and re-renders).

### Notes / limitations
- Drag reorder is mouse/trackpad only (no touch-drag shim vendored) — fine for the desktop admin/exec editor.
- Image search returns up to 24 results per query (shared-panel default); no pagination in the picker.
- Event images use a new `images` field rather than overloading `popup[1]`/`popup[2]` (which the viewer renders as activity buttons), to avoid breaking curated timelines.

### Testing
- PHP files lint clean; JS parses clean.
- Verified live in the local Docker container at `localhost:48080` (editor requires admin/exec login).

